### PR TITLE
Style: 디자인 시스템 수정에 따른 버튼 컴포넌트 폰트 사이즈 변경

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva("rounded-lg transition-colors focus:outline-none disa
     size: {
       sm: "px-4 py-1 text-sm",
       md: "px-6 py-2 text-base",
-      lg: "px-6 py-3 text-xl",
+      lg: "px-6 py-3 text-lg",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## 🚀 PR 요약

> 피그마 폰트 디자인 시스템 수정에 따라 버튼 컴포넌트 폰트 사이즈 변경했습니다.

## ✏️ 변경 유형

- style: 코드 포맷팅 등 스타일 변경

## 🗒️ 상세 내용 (선택)

### 작업 사항

- Button 컴포넌트의 텍스트 사이즈를 text-xl → text-lg로 변경
  - 기존: Text-lg: text-xl(20px)
  - 수정: Text-lg: text-lg(18px)

### 스크린 샷

<img width="1236" height="532" alt="스크린샷 2025-10-31 오전 11 00 49" src="https://github.com/user-attachments/assets/e2c2c3c7-6015-4db8-a981-36a904ebab4f" />
- 수정된 피그마 폰트 디자인 시스템

## 🔗 연관된 이슈

> closes #28 <- 이번에 작업한 이슈 번호
