### PR TITLE
Chore: Tanstack query 설치 및 세팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.16",
+        "@tanstack/react-query": "^5.90.6",
+        "@tanstack/react-query-devtools": "^5.90.2",
         "axios": "^1.13.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1472,6 +1474,55 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.6.tgz",
+      "integrity": "sha512-AnZSLF26R8uX+tqb/ivdrwbVdGemdEDm1Q19qM6pry6eOZ6bEYiY7mWhzXT1YDIPTNEVcZ5kYP9nWjoxDLiIVw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.90.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
+      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.6.tgz",
+      "integrity": "sha512-gB1sljYjcobZKxjPbKSa31FUTyr+ROaBdoH+wSSs9Dk+yDCmMs+TkTV3PybRRVLC7ax7q0erJ9LvRWnMktnRAw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
+      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.90.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.2",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.16",
+    "@tanstack/react-query": "^5.90.6",
+    "@tanstack/react-query-devtools": "^5.90.2",
     "axios": "^1.13.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,0 +1,13 @@
+import { useState, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+export default function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router";
+import Providers from "@/components/Providers.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Providers>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Providers>
   </StrictMode>
 );


### PR DESCRIPTION
## 🚀 PR 요약

> Tanstack query 설치 및 세팅

## ✏️ 변경 유형

- chore: 기타 변경사항

## 🗒️ 상세 내용 (선택)

### 작업 사항

- tanstack query 설치
- tanstack query dev tool 설치
- tanstack query Provider 설치

### 참고 사항

- 화면 하단에 나오는 야자수 버튼을 클릭 해서 tanstack query dev tool을 열 수 있습니다.
- tanstack query dev tool은 프로덕션 환경에선 보이지 않습니다.
- dev tool에선 현재 캐싱 되어 있는 키, fetch url, fetch data 등을 체크할 수 있습니다.

### 스크린 샷

+ dev tool 버튼
<img width="678" height="506" alt="Screenshot 2025-11-03 at 1 48 49 PM" src="https://github.com/user-attachments/assets/1c603865-f27f-4760-bf87-a631114c7295" />

+ dev tool ui
<img width="1058" height="548" alt="Screenshot 2025-11-03 at 1 49 19 PM" src="https://github.com/user-attachments/assets/b6b58662-15df-4657-97ad-7b2afd39697f" />

## 🔗 연관된 이슈

> closes #47
