### PR TITLE
Fix: 모달 모바일 오버레이 이슈

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -38,7 +38,7 @@ export default function Modal({
         role="dialog"
         aria-modal="true"
         className={cn(
-          "relative flex h-dvh flex-col gap-5 bg-neutral-50 p-6 sm:h-auto sm:w-[360px] sm:rounded-xl sm:border sm:border-neutral-400",
+          "relative flex h-dvh w-full flex-col gap-5 bg-neutral-50 p-6 sm:h-auto sm:w-[360px] sm:rounded-xl sm:border sm:border-neutral-400",
           className
         )}
       >


### PR DESCRIPTION
## 🚀 PR 요약

> 모바일(sm 이하) 화면에서 모달 오버레이가 전체 화면을 덮지 않던 문제를 수정했습니다.

## ✏️ 변경 유형

- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `Modal` 컴포넌트에서 `w-full` 누락으로 인한 오버레이 여백 발생 버그 수정
- 오버레이가 전체 화면을 정상적으로 덮도록 수정

### 스크린 샷


https://github.com/user-attachments/assets/6691f333-faf8-44bc-8737-ced39d7c81d8



## 🔗 연관된 이슈

> closes #53
