### PR TITLE
Fix: 특정 사이즈 이하에서 PillSearchInput의 아이콘 사라짐 문제 해결

### DIFF
--- a/src/components/PillSearchInput.tsx
+++ b/src/components/PillSearchInput.tsx
@@ -23,13 +23,13 @@ export default function PillSearchInput({ className }: PillSearchInputProps) {
     <div
       className={cn("flex items-center gap-2.5 rounded-lg border border-green-600 p-4", className)}
     >
-      <form onSubmit={handleSubmit} className="flex flex-1 items-center gap-2.5">
+      <form onSubmit={handleSubmit} className="flex min-w-0 flex-1 items-center gap-2.5">
         <button type="submit">
           <SearchIcon className="text-neutral-400 transition-colors hover:text-neutral-500" />
         </button>
 
         <input
-          className="flex-1 text-neutral-900 placeholder:text-neutral-400 focus:outline-none"
+          className="min-w-0 flex-1 overflow-hidden text-neutral-900 placeholder:text-neutral-400 focus:outline-none"
           placeholder="약 이름을 입력해주세요."
         />
       </form>


### PR DESCRIPTION
## 🚀 PR 요약

> 특정 사이즈 이하에서 PillSearchInput의 아이콘 사라짐 문제 해결

## ✏️ 변경 유형

- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- form, input 태그에 min-w-0 추가

### 참고 사항

- 화면 사이즈별로 다른 placeholder 사이즈 도입 고려해봐도 좋을 것 같습니다.

### 스크린 샷
+ 해결 전
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/bad573ba-505f-4ebc-bf8c-2f527fa10b8c" />


+ 해결 후
<img width="270" height="432" alt="Screenshot 2025-11-04 at 2 19 56 PM" src="https://github.com/user-attachments/assets/e9099328-0ae8-40d0-81d5-ca2cf0a893df" />


## 🔗 연관된 이슈

> closes #60
