### PR TITLE
Feature: 로그인 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import RootLayout from "@/components/layouts/RootLayout";
 import Home from "@/pages/Home";
 import PillList from "@/pages/PillList";
 import SignUp from "@/pages/SignUp";
+import Login from "@/pages/Login";
 import { Route, Routes } from "react-router";
 
 function App() {
@@ -11,6 +12,7 @@ function App() {
         <Route index element={<Home />} />
         <Route path="/pill" element={<PillList />} />
         <Route path="/sign-up" element={<SignUp />} />
+        <Route path="/login" element={<Login />} />
       </Route>
     </Routes>
   );

--- a/src/hooks/api/auth/index.ts
+++ b/src/hooks/api/auth/index.ts
@@ -2,3 +2,4 @@ export * from "./useSendCodeMutation";
 export * from "./useVerifyCodeMutation";
 export * from "./useSignupMutation";
 export * from "./useLoginMutation";
+export * from "./useLogoutMutation";

--- a/src/hooks/api/auth/index.ts
+++ b/src/hooks/api/auth/index.ts
@@ -1,3 +1,4 @@
 export * from "./useSendCodeMutation";
 export * from "./useVerifyCodeMutation";
 export * from "./useSignupMutation";
+export * from "./useLoginMutation";

--- a/src/hooks/api/auth/useLoginMutation.ts
+++ b/src/hooks/api/auth/useLoginMutation.ts
@@ -1,0 +1,40 @@
+import { api } from "@/libs/axios";
+import type { LoginRequest } from "@/types/api-request-types/auth-request-types";
+import { AxiosError, type AxiosResponse } from "axios";
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+import { useAuthStore } from "@/hooks/stores/useAuthStore";
+import type {
+  LoginApiErrorResponse,
+  LoginResponse,
+} from "@/types/api-response-types/auth-response-types";
+import { MSW_BASE_URL } from "@/constants/url-constants";
+
+// 로그인 요청 처리 TanStack Query 훅
+// - /users/login 엔드포인트로 로그인 요청을 보내고,
+// - 성공 시 서버에서 받은 user / accessToken을 Zustand 스토어에 저장
+
+export function useLoginMutation(
+  options?: UseMutationOptions<LoginResponse, AxiosError<LoginApiErrorResponse>, LoginRequest>
+) {
+  const setAuth = useAuthStore((state) => state.setAuth);
+
+  return useMutation<LoginResponse, AxiosError<LoginApiErrorResponse>, LoginRequest>({
+    mutationKey: ["auth", "login"],
+    mutationFn: (payload) =>
+      api
+        .post<
+          LoginResponse,
+          AxiosResponse<LoginResponse>,
+          LoginRequest
+        >(`${MSW_BASE_URL}/users/login`, payload)
+        .then((res) => res.data),
+    onSuccess: (data) => {
+      // 로그인 성공 시, 유저 정보와 엑세스 토근을 전역 상태에 저장
+      setAuth({
+        user: data.user,
+        accessToken: data.tokens.access_token,
+      });
+    },
+    ...options,
+  });
+}

--- a/src/hooks/api/auth/useLogoutMutation.ts
+++ b/src/hooks/api/auth/useLogoutMutation.ts
@@ -1,0 +1,23 @@
+import { api } from "@/libs/axios";
+import { useAuthStore } from "@/hooks/stores/useAuthStore";
+import type { LogoutResponse } from "@/types/api-response-types/auth-response-types";
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+import { useNavigate } from "react-router";
+import { MSW_BASE_URL } from "@/constants/url-constants";
+
+export function useLogoutMutation(options?: UseMutationOptions<LogoutResponse, AxiosError>) {
+  const navigate = useNavigate();
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+
+  return useMutation({
+    mutationKey: ["auth", "logout"],
+    mutationFn: () =>
+      api.post<LogoutResponse>(`${MSW_BASE_URL}/user/logout`).then((res) => res.data),
+    onSettled: () => {
+      clearAuth();
+      navigate("/login", { replace: true });
+    },
+    ...options,
+  });
+}

--- a/src/hooks/stores/useAuthStore.ts
+++ b/src/hooks/stores/useAuthStore.ts
@@ -1,5 +1,6 @@
 import type { User } from "@/types/api-response-types/auth-response-types";
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 type AuthState = {
   user: User | null;
@@ -9,10 +10,15 @@ type AuthState = {
   clearAuth: () => void;
 };
 
-export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  accessToken: null,
-  isAuthed: false,
-  setAuth: ({ user, accessToken }) => set({ user, accessToken, isAuthed: true }),
-  clearAuth: () => set({ user: null, accessToken: null, isAuthed: false }),
-}));
+export const useAuthStore = create<AuthState, [["zustand/persist", AuthState]]>(
+  persist(
+    (set) => ({
+      user: null,
+      accessToken: null,
+      isAuthed: false,
+      setAuth: ({ user, accessToken }) => set({ user, accessToken, isAuthed: true }),
+      clearAuth: () => set({ user: null, accessToken: null, isAuthed: false }),
+    }),
+    { name: "auth-storage" } // 로컬스토리지 저장 키 이름
+  )
+);

--- a/src/hooks/stores/useAuthStore.ts
+++ b/src/hooks/stores/useAuthStore.ts
@@ -1,0 +1,18 @@
+import type { User } from "@/types/api-response-types/auth-response-types";
+import { create } from "zustand";
+
+type AuthState = {
+  user: User | null;
+  accessToken: string | null;
+  isAuthed: boolean;
+  setAuth: (authData: { user: User; accessToken: string }) => void;
+  clearAuth: () => void;
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  accessToken: null,
+  isAuthed: false,
+  setAuth: ({ user, accessToken }) => set({ user, accessToken, isAuthed: true }),
+  clearAuth: () => set({ user: null, accessToken: null, isAuthed: false }),
+}));

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,5 +1,59 @@
-import axios from "axios";
+import { useAuthStore } from "@/hooks/stores/useAuthStore";
+import axios, { AxiosError } from "axios";
 
 export const api = axios.create({
   withCredentials: true,
 });
+
+// 요청 인터셉터
+api.interceptors.request.use((config) => {
+  console.log("요청 인터셉터 실행");
+
+  const token = useAuthStore.getState().accessToken;
+
+  // headers가 undefined일 수 있으므로 안전하게 기본값 설정
+  config.headers = config.headers ?? {};
+
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  console.log("요청 전송:", config.url, config.method);
+  return config;
+});
+
+// 응답 인터셉터
+api.interceptors.response.use(
+  // 성공 응답
+  (response) => response,
+
+  // 실패 응답
+  async (error: AxiosError) => {
+    const { response, config } = error;
+
+    // accessToken 만료 감시 및 중복 재시도 방지
+    if (response?.status === 401 && config && !(config as any)._retry) {
+      (config as any)._retry = true;
+
+      try {
+        // refresh 요청 (rToken은 쿠키로 자동 전송)
+        const { data } = await api.post("/user/token/refresh");
+        console.log("새 accessToken 발급 성공");
+
+        // 새 accessToken 전역 상태에 저장
+        const newAccessToken = data?.tokens?.access_token ?? data?.access_token;
+        if (newAccessToken) {
+          const state = useAuthStore.getState();
+          useAuthStore.setState({ ...state, accessToken: newAccessToken });
+          console.log("accessToken 업데이트 완료");
+
+          return api(config);
+        }
+      } catch (refreshError) {
+        // refresh 자체가 실패하면 로그인 상태 초기화
+        console.log("refresh 실패로 로그아웃 처리");
+        useAuthStore.getState().clearAuth();
+      }
+    }
+    return Promise.reject(error);
+  }
+);

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,3 +1,4 @@
+import { MSW_BASE_URL } from "@/constants/url-constants";
 import { useAuthStore } from "@/hooks/stores/useAuthStore";
 import axios, { AxiosError } from "axios";
 
@@ -36,7 +37,11 @@ api.interceptors.response.use(
 
       try {
         // refresh 요청 (rToken은 쿠키로 자동 전송)
-        const { data } = await api.post("/user/token/refresh");
+        const { data } = await axios.post(
+          `${MSW_BASE_URL}/user/token/refresh`,
+          {},
+          { withCredentials: true }
+        );
         console.log("새 accessToken 발급 성공");
 
         // 새 accessToken 전역 상태에 저장

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -6,15 +6,18 @@ import {
 import { MSW_BASE_URL } from "@/constants/url-constants";
 import { mockSignUpResponse } from "@/mocks/data/signup-data";
 import type {
+  LoginRequest,
   SignUpRequest,
   SignUpSendRequest,
   SignUpVerifyRequest,
 } from "@/types/api-request-types/auth-request-types";
-import type {
-  SignUpApiErrorResponse,
-  SignUpResponse,
-  SignUpSendResponse,
-  SignUpVerifyResponse,
+import {
+  type LoginApiErrorResponse,
+  type LoginResponse,
+  type SignUpApiErrorResponse,
+  type SignUpResponse,
+  type SignUpSendResponse,
+  type SignUpVerifyResponse,
 } from "@/types/api-response-types/auth-response-types";
 import { http, HttpResponse } from "msw";
 
@@ -111,4 +114,66 @@ const postSignUp = http.post<never, SignUpRequest>(
   }
 );
 
-export const authHandlers = [postSignUpSend, postSignUpVerify, postSignUp];
+// 로그인 API
+const postLogin = http.post<never, LoginRequest>(
+  `${MSW_BASE_URL}/users/login`,
+  async ({ request }) => {
+    const body = (await request.json()) as LoginRequest;
+    const { email, password } = body;
+
+    if (email !== "jane.doe@example.com" || password !== "Password123!") {
+      return HttpResponse.json<LoginApiErrorResponse>(
+        { error: "이메일 또는 비밀번호를 확인해주세요", code: 401 },
+        { status: 401 }
+      );
+    }
+
+    return HttpResponse.json<LoginResponse>({
+      user: {
+        id: "user1",
+        email,
+        nickname: "jane_doe",
+        is_active: true,
+        joined_at: new Date().toISOString(),
+        last_login: null,
+        provider: null,
+      },
+      tokens: {
+        token_type: "Bearer",
+        access_token: "mock-access-" + crypto.randomUUID(),
+        access_expires_in: ACCESS_TOKEN_EXPIRE_SECONDS,
+        refresh_expires_at: new Date(
+          Date.now() + REFRESH_TOKEN_EXPIRE_DAYS * MS_PER_DAY
+        ).toISOString(),
+      },
+    });
+  }
+);
+
+// 토큰 갱신 API
+const postRefresh = http.post(`${MSW_BASE_URL}/user/token/refresh`, async () => {
+  return HttpResponse.json({
+    tokens: {
+      token_type: "Bearer",
+      access_token: "mock-access-" + crypto.randomUUID(),
+      access_expires_in: ACCESS_TOKEN_EXPIRE_SECONDS,
+      refresh_expires_at: new Date(
+        Date.now() + REFRESH_TOKEN_EXPIRE_DAYS * MS_PER_DAY
+      ).toISOString(),
+    },
+  });
+});
+
+// 로그아웃 API
+const postLogout = http.post(`${MSW_BASE_URL}/user/logout`, async () => {
+  return HttpResponse.json({ message: "로그아웃하셨습니다" });
+});
+
+export const authHandlers = [
+  postSignUpSend,
+  postSignUpVerify,
+  postSignUp,
+  postLogin,
+  postRefresh,
+  postLogout,
+];

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <div>Login</div>;
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,56 @@
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
-import { Link } from "react-router";
+import GoogleButton from "@/components/social-login-button/GoogleButton";
+import KakaoButton from "@/components/social-login-button/KakaoButton";
+import { useLoginMutation } from "@/hooks/api/auth";
+import { loginSchema, type LoginSchema } from "@/schema/auth-schema";
+import type { LoginApiErrorResponse } from "@/types/api-response-types/auth-response-types";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { AxiosError } from "axios";
+import { useForm } from "react-hook-form";
+import { Link, useNavigate } from "react-router";
+
+const getApiError = (error: unknown) => {
+  const axiosError = error as AxiosError<LoginApiErrorResponse>;
+  return axiosError?.response?.data?.error ?? null;
+};
 
 export default function Login() {
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    // TODO: 로그인 요청 로직
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginSchema>({
+    resolver: zodResolver(loginSchema),
+    mode: "onChange",
+  });
+
+  // TanStack Query mutations 로그인
+  const login = useLoginMutation({
+    onSuccess: () => {
+      navigate("/", { replace: true });
+    },
+    onError: (error) => {
+      const axiosError = error as AxiosError<LoginApiErrorResponse>;
+      const status = axiosError?.response?.status ?? axiosError?.response?.data?.code;
+      const msg = getApiError(error) ?? "로그인 중 오류가 발생했습니다.";
+
+      if (status === 400 || status === 401) {
+        setError("email", { message: "이메일 또는 비밀번호를 확인해주세요." });
+      } else if (status === 500) {
+        setError("email", { message: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요." });
+      } else {
+        setError("email", { message: msg });
+      }
+    },
+  });
+
+  // 로그인 요청
+  const onSubmit = (data: LoginSchema) => {
+    login.mutate(data);
   };
 
   const handleGoogleLogin = () => {
@@ -23,55 +68,49 @@ export default function Login() {
         <h2 className="text-5xl text-neutral-900">로그인</h2>
       </div>
 
-      <form onSubmit={handleSubmit} className="grid gap-5">
+      <form onSubmit={handleSubmit(onSubmit)} className="grid gap-5" noValidate>
         <Input
           label="이메일"
           type="email"
           placeholder="example@example.com"
           autoComplete="email"
-          required
-          errorMessage="이메일 형식을 지켜주세요."
+          {...register("email")}
+          errorMessage={errors.email?.message}
+          inputClassName="h-14 p-4"
         />
+
         <Input
           type="password"
           label="비밀번호"
-          placeholder="비밀번호를 입력하세요."
-          minLength={10}
-          required
-          errorMessage="비밀번호를 10자리 이상 입력해주세요."
+          placeholder="비밀번호를 입력하세요. (8자 이상)"
+          autoComplete="current-password"
+          {...register("password")}
+          errorMessage={errors.password?.message}
+          inputClassName="h-14 p-4"
         />
-        <Button type="submit" variant={"primary"} size={"lg"} className="w-full">
-          로그인
+
+        <Button
+          type="submit"
+          variant={"primary"}
+          size={"lg"}
+          className="h-14 w-full"
+          disabled={isSubmitting || login.isPending}
+        >
+          {isSubmitting || login.isPending ? "로그인 중" : "로그인"}
         </Button>
-        <div>
-          <p>아이디가 없다면?</p>
-          <Link
-            to="/sign-up"
-            className="inline-flex w-full items-center justify-center rounded-lg border border-green-600 bg-neutral-50 px-6 py-3 text-lg text-neutral-900 transition-colors hover:bg-neutral-200 focus:outline-none disabled:saturate-50"
-          >
-            회원가입
+
+        <div className="grid gap-1">
+          <p className="text-base text-neutral-900">아이디가 없다면?</p>
+          <Link to="/sign-up">
+            <Button variant={"primaryOutline"} size={"lg"} className="h-14 w-full">
+              회원가입
+            </Button>
           </Link>
         </div>
 
         <div className="flex gap-3">
-          <Button
-            type="button"
-            variant={"neutralOutline"}
-            size={"lg"}
-            className="flex-1"
-            onClick={handleGoogleLogin}
-          >
-            구글 로그인
-          </Button>
-          <Button
-            type="button"
-            variant={"neutralOutline"}
-            size={"lg"}
-            className="flex-1"
-            onClick={handleKakaoLogin}
-          >
-            카카오 로그인
-          </Button>
+          <GoogleButton onClick={handleGoogleLogin} />
+          <KakaoButton onClick={handleKakaoLogin} />
         </div>
       </form>
     </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,3 +1,79 @@
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+import { Link } from "react-router";
+
 export default function Login() {
-  return <div>Login</div>;
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // TODO: 로그인 요청 로직
+  };
+
+  const handleGoogleLogin = () => {
+    // TODO: 구글 로그인 로직
+  };
+
+  const handleKakaoLogin = () => {
+    // TODO: 카카오 로그인 로직
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-col justify-center gap-6 pt-20">
+      <div className="grid gap-2">
+        <p className="text-lg text-neutral-900">이게뭐약 사용자 로그인</p>
+        <h2 className="text-5xl text-neutral-900">로그인</h2>
+      </div>
+
+      <form onSubmit={handleSubmit} className="grid gap-5">
+        <Input
+          label="이메일"
+          type="email"
+          placeholder="example@example.com"
+          autoComplete="email"
+          required
+          errorMessage="이메일 형식을 지켜주세요."
+        />
+        <Input
+          type="password"
+          label="비밀번호"
+          placeholder="비밀번호를 입력하세요."
+          minLength={10}
+          required
+          errorMessage="비밀번호를 10자리 이상 입력해주세요."
+        />
+        <Button type="submit" variant={"primary"} size={"lg"} className="w-full">
+          로그인
+        </Button>
+        <div>
+          <p>아이디가 없다면?</p>
+          <Link
+            to="/sign-up"
+            className="inline-flex w-full items-center justify-center rounded-lg border border-green-600 bg-neutral-50 px-6 py-3 text-lg text-neutral-900 transition-colors hover:bg-neutral-200 focus:outline-none disabled:saturate-50"
+          >
+            회원가입
+          </Link>
+        </div>
+
+        <div className="flex gap-3">
+          <Button
+            type="button"
+            variant={"neutralOutline"}
+            size={"lg"}
+            className="flex-1"
+            onClick={handleGoogleLogin}
+          >
+            구글 로그인
+          </Button>
+          <Button
+            type="button"
+            variant={"neutralOutline"}
+            size={"lg"}
+            className="flex-1"
+            onClick={handleKakaoLogin}
+          >
+            카카오 로그인
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -65,7 +65,7 @@ export default function Login() {
     <div className="mx-auto flex w-full max-w-md flex-col justify-center gap-6 pt-20">
       <div className="grid gap-2">
         <p className="text-lg text-neutral-900">이게뭐약 사용자 로그인</p>
-        <h2 className="text-5xl text-neutral-900">로그인</h2>
+        <h2 className="text-5xl font-semibold text-neutral-900">로그인</h2>
       </div>
 
       <form onSubmit={handleSubmit(onSubmit)} className="grid gap-5" noValidate>

--- a/src/schema/auth-schema.ts
+++ b/src/schema/auth-schema.ts
@@ -43,3 +43,11 @@ export const signupSchema = z
   });
 
 export type SignupSchema = z.infer<typeof signupSchema>;
+
+// 로그인 스키마
+export const loginSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+});
+
+export type LoginSchema = z.infer<typeof loginSchema>;

--- a/src/types/api-request-types/auth-request-types.ts
+++ b/src/types/api-request-types/auth-request-types.ts
@@ -1,3 +1,4 @@
+// 회원가입 요청
 export interface SignUpRequest {
   email: string;
   password: string;
@@ -11,4 +12,10 @@ export interface SignUpSendRequest {
 export interface SignUpVerifyRequest {
   email: string;
   auth_code: string;
+}
+
+// 로그인 요청
+export interface LoginRequest {
+  email: string;
+  password: string;
 }

--- a/src/types/api-response-types/auth-response-types.ts
+++ b/src/types/api-response-types/auth-response-types.ts
@@ -1,19 +1,29 @@
+// 로그인/회원가입 공통 타입
+export interface User {
+  id: string;
+  email: string;
+  nickname: string;
+  is_active: boolean;
+  joined_at: string;
+  last_login: string | null;
+  provider: string | null;
+}
+
+export interface Token {
+  token_type: "Bearer";
+  access_token: string;
+  access_expires_in: number;
+  refresh_expires_at: string;
+}
+export interface ApiError {
+  error: string;
+  code: number;
+}
+
+// 회원가입 응답
 export interface SignUpResponse {
-  user: {
-    id: string;
-    email: string;
-    nickname: string;
-    is_active: boolean;
-    joined_at: string;
-    last_login: string | null;
-    provider: string | null;
-  };
-  tokens: {
-    token_type: "Bearer";
-    access_token: string;
-    access_expires_in: number;
-    refresh_expires_at: string;
-  };
+  user: User;
+  tokens: Token;
 }
 
 export interface SignUpSendResponse {
@@ -24,7 +34,12 @@ export interface SignUpVerifyResponse {
   verified: boolean;
 }
 
-export interface SignUpApiErrorResponse {
-  error: string;
-  code: number;
+export type SignUpApiErrorResponse = ApiError;
+
+// 로그인 응답
+export interface LoginResponse {
+  user: User;
+  tokens: Token;
 }
+
+export type LoginApiErrorResponse = ApiError;

--- a/src/types/api-response-types/auth-response-types.ts
+++ b/src/types/api-response-types/auth-response-types.ts
@@ -43,3 +43,8 @@ export interface LoginResponse {
 }
 
 export type LoginApiErrorResponse = ApiError;
+
+// 로그아웃 응답
+export interface LogoutResponse {
+  message: string;
+}


### PR DESCRIPTION
## 🚀 PR 요약

> 로그인 페이지 구현했습니다.

## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 로그인 페이지 UI 및 폼 검증 구현 (React Hook Form + Zod)
- Axios 인터셉터 추가
- TanStack Query를 통한 /users/login API 연동
- Zustand useAuthStore 로그인 상태 관리
- persist 미들웨어 적용으로 사용자 정보 로컬스토리지에 유지

### 참고 사항

- 소셜 로그인(Google, Kakao)은 별도 PR에서 구현 예정 (후 순위)
- [zustand github - persist](https://github.com/pmndrs/zustand/blob/main/docs/integrations/persisting-store-data.md)

### 스크린 샷

https://github.com/user-attachments/assets/a6f57459-5ba1-4fdf-bc8a-235345795e05


## 🔗 연관된 이슈

> closes #59
