### PR TITLE
Feature: 로그인 후 사용자 상태 persist 스토리지 미반영 이슈

### DIFF
--- a/src/hooks/api/auth/useLoginMutation.ts
+++ b/src/hooks/api/auth/useLoginMutation.ts
@@ -13,7 +13,10 @@ import { MSW_BASE_URL } from "@/constants/url-constants";
 // - 성공 시 서버에서 받은 user / accessToken을 Zustand 스토어에 저장
 
 export default function useLoginMutation(
-  options?: UseMutationOptions<LoginResponse, AxiosError<LoginApiErrorResponse>, LoginRequest>
+  options?: Omit<
+    UseMutationOptions<LoginResponse, AxiosError<LoginApiErrorResponse>, LoginRequest>,
+    "mutationFn" | "mutationKey"
+  >
 ) {
   return useMutation<LoginResponse, AxiosError<LoginApiErrorResponse>, LoginRequest>({
     mutationKey: ["auth", "login"],

--- a/src/hooks/api/auth/useLoginMutation.ts
+++ b/src/hooks/api/auth/useLoginMutation.ts
@@ -2,7 +2,6 @@ import { api } from "@/libs/axios";
 import type { LoginRequest } from "@/types/api-request-types/auth-request-types";
 import { AxiosError, type AxiosResponse } from "axios";
 import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
-import useAuthStore from "@/hooks/stores/useAuthStore";
 import type {
   LoginApiErrorResponse,
   LoginResponse,
@@ -16,24 +15,15 @@ import { MSW_BASE_URL } from "@/constants/url-constants";
 export default function useLoginMutation(
   options?: UseMutationOptions<LoginResponse, AxiosError<LoginApiErrorResponse>, LoginRequest>
 ) {
-  const setAuth = useAuthStore((state) => state.setAuth);
-
   return useMutation<LoginResponse, AxiosError<LoginApiErrorResponse>, LoginRequest>({
     mutationKey: ["auth", "login"],
-    mutationFn: (payload) =>
-      api
-        .post<
-          LoginResponse,
-          AxiosResponse<LoginResponse>,
-          LoginRequest
-        >(`${MSW_BASE_URL}/users/login`, payload)
-        .then((res) => res.data),
-    onSuccess: (data) => {
-      // 로그인 성공 시, 유저 정보와 엑세스 토근을 전역 상태에 저장
-      setAuth({
-        user: data.user,
-        accessToken: data.tokens.access_token,
-      });
+    mutationFn: async (payload) => {
+      const res = await api.post<LoginResponse, AxiosResponse<LoginResponse>, LoginRequest>(
+        `${MSW_BASE_URL}/users/login`,
+        payload
+      );
+
+      return res.data;
     },
     ...options,
   });

--- a/src/hooks/stores/useAuthStore.ts
+++ b/src/hooks/stores/useAuthStore.ts
@@ -10,7 +10,7 @@ type AuthState = {
   clearAuth: () => void;
 };
 
-const useAuthStore = create<AuthState, [["zustand/persist", AuthState]]>(
+const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
       user: null,

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import Input from "@/components/common/Input";
 import GoogleButton from "@/components/social-login-button/GoogleButton";
 import KakaoButton from "@/components/social-login-button/KakaoButton";
 import { useLoginMutation } from "@/hooks/api/auth";
+import useAuthStore from "@/hooks/stores/useAuthStore";
 import { loginSchema, type LoginSchema } from "@/schema/auth-schema";
 import type { LoginApiErrorResponse } from "@/types/api-response-types/auth-response-types";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -17,6 +18,7 @@ const getApiError = (error: unknown) => {
 
 export default function Login() {
   const navigate = useNavigate();
+  const setAuth = useAuthStore((state) => state.setAuth);
 
   const {
     register,
@@ -30,7 +32,12 @@ export default function Login() {
 
   // TanStack Query mutations 로그인
   const login = useLoginMutation({
-    onSuccess: () => {
+    onSuccess: (data) => {
+      // 로그인 성공 시, 유저 정보와 엑세스 토근을 전역 상태에 저장
+      setAuth({
+        user: data.user,
+        accessToken: data.tokens.access_token,
+      });
       navigate("/", { replace: true });
     },
     onError: (error) => {


### PR DESCRIPTION
## 🚀 PR 요약

> 로그인 후 사용자 상태(`user`, `accessToken`, `isAuthed`)가 persist 스토리지에 반영되지 않던 버그를 수정했습니다.


## ✏️ 변경 유형

- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `useLoginMutation`의 `onSuccess` 덮어쓰기 현상 수정


## 🔗 연관된 이슈

> closes #95
