### PR TITLE
Fix: Tab 컴포넌트 onChange 콜백 추가

### DIFF
--- a/src/components/common/Tab.tsx
+++ b/src/components/common/Tab.tsx
@@ -14,6 +14,7 @@ interface TabProps {
   items: TabItem[];
   showAllKey?: string;
   className?: string;
+  onChange?: (key: string) => void;
 }
 
 /**
@@ -23,7 +24,7 @@ interface TabProps {
  * - showAllKey가 설정된 경우, '전체 보기' 탭처럼 모든 탭 콘텐츠를 순차적으로 표시할 수 있습니다.
  */
 
-export default function Tab({ items, showAllKey, className }: TabProps) {
+export default function Tab({ items, showAllKey, className, onChange }: TabProps) {
   const [activeTab, setActiveTab] = useState(showAllKey || items[0]?.key);
 
   // showAllKey가 설정되어 있고 현재 활성 탭이 해당 key라면, 모든 탭의 콘텐츠를 순차적으로 렌더링
@@ -48,7 +49,10 @@ export default function Tab({ items, showAllKey, className }: TabProps) {
           <button
             key={item.key}
             role="tab"
-            onClick={() => setActiveTab(item.key)}
+            onClick={() => {
+              setActiveTab(item.key);
+              onChange?.(item.key);
+            }}
             className={cn(
               "flex-1 px-1 py-1 text-lg text-neutral-600",
               activeTab === item.key


### PR DESCRIPTION
## 🚀 PR 요약

> Tab 컴포넌트에 onChange 콜백을 추가해 상위 컴포넌트에서도 탭 전환 상태를 감지할 수 있도록 개선했습니다.

## ✏️ 변경 유형

- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- Tab 컴포넌트에 onChange 콜백 prop 추가

### 참고 사항

- 기존 컴포넌트 사용 페이지에 영향 없음을 확인했습니다.

## 🔗 연관된 이슈

> closes #100 
