### PR TITLE
Fix: 회원가입 유저 플로우 변경에 따른 불필요 코드/타입 정리

### DIFF
--- a/src/mocks/data/signup-data.ts
+++ b/src/mocks/data/signup-data.ts
@@ -10,10 +10,4 @@ export const mockSignUpResponse: SignUpResponse = {
     last_login: null,
     provider: null,
   },
-  tokens: {
-    token_type: "Bearer",
-    access_token: "mock-access-token",
-    access_expires_in: 900,
-    refresh_expires_at: "2025-11-18T02:13:45Z",
-  },
 };

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -100,14 +100,6 @@ const postSignUp = http.post<never, SignUpRequest>(
           last_login: null,
           provider: null,
         },
-        tokens: {
-          token_type: "Bearer",
-          access_token: "mock-access-" + crypto.randomUUID(),
-          access_expires_in: ACCESS_TOKEN_EXPIRE_SECONDS,
-          refresh_expires_at: new Date(
-            Date.now() + REFRESH_TOKEN_EXPIRE_DAYS * MS_PER_DAY
-          ).toISOString(),
-        },
       },
       { status: 201 }
     );

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -87,8 +87,7 @@ export default function SignUp() {
   const signup = useSignupMutation({
     onSuccess: () => {
       console.log("회원가입 성공");
-      // 회원가입 시 access/refresh 토큰이 발급되므로 로그인 페이지 대신 홈으로 리다이렉트
-      navigate("/", { replace: true });
+      navigate("/login", { replace: true });
     },
     onError: (error) => {
       const axiosError = error as AxiosError<SignUpApiErrorResponse>;

--- a/src/types/api-response-types/auth-response-types.ts
+++ b/src/types/api-response-types/auth-response-types.ts
@@ -23,7 +23,6 @@ export interface ApiError {
 // 회원가입 응답
 export interface SignUpResponse {
   user: User;
-  tokens: Token;
 }
 
 export interface SignUpSendResponse {


### PR DESCRIPTION
## 🚀 PR 요약

> 회원가입 타입 정리 및 경로 수정

## ✏️ 변경 유형

- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 토큰 응답 타입 제거
- 회원가입 성공 시 navigate("/login") 으로 이동

## 🔗 연관된 이슈

> closes #98
