### PR TITLE
Feature: 홈에서 의약품 검색 시 리스트 페이지로 이동

### DIFF
--- a/src/components/PillSearchInput.tsx
+++ b/src/components/PillSearchInput.tsx
@@ -4,6 +4,9 @@ import usePillSearchStore from "@/hooks/stores/usePillSearchStore";
 import { cn } from "@/libs/utils";
 import { CameraIcon, ImageIcon, SearchIcon } from "lucide-react";
 import React, { useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+const PILL_PATH = "/pill";
 
 interface PillSearchInputProps {
   className?: string;
@@ -15,8 +18,15 @@ export default function PillSearchInput({ className }: PillSearchInputProps) {
   const { setQueryParamValue } = usePillSearchStore();
   const [inputValue, setInputValue] = useState("");
 
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
+
+    if (location.pathname !== PILL_PATH) {
+      navigate(PILL_PATH);
+    }
 
     setQueryParamValue(inputValue.trim());
   };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 
 export default function Home() {
   const [pillList, setPillList] = useState<Pill[]>([]);
-  const [loading, setLoading] = useState(true); 
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -28,43 +28,36 @@ export default function Home() {
     fetchPills();
   }, []);
 
-
   return (
     <div className="flex min-h-screen flex-col">
       {/* 메인 콘텐츠 */}
       <main className="flex-1 px-4 py-8 sm:px-8">
-        <div className="max-w-5xl mx-auto flex flex-col gap-8">
+        <div className="mx-auto flex max-w-5xl flex-col gap-8">
           {/* 검색 바 */}
           <PillSearchInput className="w-full" />
 
           {/* 배너 (회색 영역) */}
-          <div className="w-full bg-neutral-200 h-48 sm:h-64 rounded-lg flex items-center justify-center text-neutral-500 text-lg">
+          <div className="flex h-48 w-full items-center justify-center rounded-lg bg-neutral-200 text-lg text-neutral-500 sm:h-64">
             배너 이미지 영역
           </div>
 
+          <h1 className="text-4xl font-semibold text-neutral-900">대표 의약품</h1>
+
           {/* 로딩 상태 */}
           {loading && (
-            <div className="text-center text-neutral-500 py-8">
-              약 목록을 불러오는 중입니다...
-            </div>
+            <div className="py-8 text-center text-neutral-500">약 목록을 불러오는 중입니다...</div>
           )}
 
           {/* 에러 상태 */}
-          {error && (
-            <div className="text-center text-red-500 py-8">{error}</div>
-          )}
+          {error && <div className="py-8 text-center text-red-500">{error}</div>}
 
           {/* 정상 데이터 */}
           {!loading && !error && (
             <div className="flex flex-col gap-3">
               {pillList.length > 0 ? (
-                pillList.map((pill) => (
-                  <PillListItem key={pill.item_seq} pill={pill} />
-                ))
+                pillList.map((pill) => <PillListItem key={pill.item_seq} pill={pill} />)
               ) : (
-                <div className="text-center text-neutral-500 py-8">
-                  표시할 약이 없습니다
-                </div>
+                <div className="py-8 text-center text-neutral-500">표시할 약이 없습니다</div>
               )}
             </div>
           )}


### PR DESCRIPTION
## 🚀 PR 요약

> 홈에서 의약품 검색 시 리스트 페이지로 이동

## ✏️ 변경 유형

- feat: 새로운 기능 추가


## 🗒️ 상세 내용 (선택)

### 작업 사항

- 홈에서 의약품 검색 시 리스트 페이지로 이동
- 대표 의약품 제목

### 스크린 샷

https://github.com/user-attachments/assets/ac9d9499-6aa1-44b6-a3bd-66c777f450ad



## 🔗 연관된 이슈

> closes #106 
