### PR TITLE
Refactor: axios 직접 호출을 공통 api 인스턴스로 통일

### DIFF
--- a/src/hooks/api/my-page/useBookmarkList.ts
+++ b/src/hooks/api/my-page/useBookmarkList.ts
@@ -1,13 +1,13 @@
 import { MSW_BASE_URL } from "@/constants/url-constants";
+import { api } from "@/libs/axios";
 import type { BookmarkListResponse } from "@/types/api-response-types/bookmark-response-types";
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
 
 export default function useBookmarkList() {
   return useQuery<BookmarkListResponse>({
     queryKey: ["bookmark"],
     queryFn: async () => {
-      const res = await axios.get(`${MSW_BASE_URL}/bookmark`);
+      const res = await api.get(`${MSW_BASE_URL}/bookmark`);
       return res.data;
     },
   });

--- a/src/hooks/api/useInfinitePillList.ts
+++ b/src/hooks/api/useInfinitePillList.ts
@@ -1,5 +1,6 @@
 import { PILL_LIST_PAGE_LIMIT, PILL_SEARCH_OPTION_MAP } from "@/constants/api-constants";
 import { MSW_BASE_URL } from "@/constants/url-constants";
+import { api } from "@/libs/axios";
 import type { PillList } from "@/types/api-response-types/pill-response-types";
 import type { pillSearchOptionFrontend } from "@/types/types";
 import {
@@ -7,7 +8,6 @@ import {
   type InfiniteData,
   type UseInfiniteQueryOptions,
 } from "@tanstack/react-query";
-import axios from "axios";
 
 type useInfinitePillListOption = Omit<
   UseInfiniteQueryOptions<PillList, Error, InfiniteData<PillList>, readonly unknown[], number>,
@@ -35,7 +35,7 @@ export default function useInfinitePillList(
 
         const trimmedValue = queryParamValue.trim();
 
-        const res = await axios.get(`${MSW_BASE_URL}/pills/search`, {
+        const res = await api.get(`${MSW_BASE_URL}/pills/search`, {
           params: {
             page: pageParam,
             [PILL_SEARCH_OPTION_MAP[queryParamKey]]: trimmedValue,
@@ -45,7 +45,7 @@ export default function useInfinitePillList(
         return res.data;
       } else {
         //검색어가 없을 때
-        const res = await axios.get(`${MSW_BASE_URL}/pills`, {
+        const res = await api.get(`${MSW_BASE_URL}/pills`, {
           params: {
             page: pageParam,
           },

--- a/src/hooks/api/usePillList.ts
+++ b/src/hooks/api/usePillList.ts
@@ -1,7 +1,7 @@
 import { MSW_BASE_URL } from "@/constants/url-constants";
+import { api } from "@/libs/axios";
 import type { PillList } from "@/types/api-response-types/pill-response-types";
 import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
-import axios from "axios";
 
 /** depreciate useInfinitePillList로 기능 이관 */
 export default function usePillList(
@@ -10,7 +10,7 @@ export default function usePillList(
   return useQuery<PillList>({
     queryKey: ["pill"],
     queryFn: async () => {
-      const res = await axios.get(`${MSW_BASE_URL}/pills`);
+      const res = await api.get(`${MSW_BASE_URL}/pills`);
 
       return res.data;
     },

--- a/src/hooks/api/useToggleBookmark.ts
+++ b/src/hooks/api/useToggleBookmark.ts
@@ -1,7 +1,7 @@
 import { MSW_BASE_URL } from "@/constants/url-constants";
+import { api } from "@/libs/axios";
 import type { BoomarkResponse } from "@/types/api-response-types/bookmark-response-types";
 import { useMutation, type MutateOptions } from "@tanstack/react-query";
-import axios from "axios";
 
 interface UseToggleBookmarkParams {
   isDelete: boolean;
@@ -20,7 +20,7 @@ export default function useToggleBookmark(
       const { id, isDelete } = toggleParams;
 
       if (isDelete) {
-        const res = await axios.delete(`${MSW_BASE_URL}/bookmark`, {
+        const res = await api.delete(`${MSW_BASE_URL}/bookmark`, {
           data: {
             item_seq: id,
           },
@@ -28,7 +28,7 @@ export default function useToggleBookmark(
 
         return res.data;
       } else {
-        const res = await axios.post(`${MSW_BASE_URL}/bookmark`, {
+        const res = await api.post(`${MSW_BASE_URL}/bookmark`, {
           item_seq: id,
         });
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,9 @@
-import axios from "axios";
 import { MSW_BASE_URL } from "@/constants/url-constants";
 import type { Pill } from "@/types/api-response-types/pill-response-types";
 import PillSearchInput from "@/components/PillSearchInput";
 import PillListItem from "@/components/PillListItem";
 import { useEffect, useState } from "react";
+import { api } from "@/libs/axios";
 
 export default function Home() {
   const [pillList, setPillList] = useState<Pill[]>([]);
@@ -14,7 +14,7 @@ export default function Home() {
     const fetchPills = async () => {
       try {
         setLoading(true);
-        const res = await axios.get(`${MSW_BASE_URL}/pills/`, {
+        const res = await api.get(`${MSW_BASE_URL}/pills/`, {
           params: { page: 1 },
         });
         setPillList(res.data.pills);


### PR DESCRIPTION
## 🚀 PR 요약

> 기존 axios 직접 호출을 공통 api 인스턴스로 통일했습니다.

## ✏️ 변경 유형

- refactor: 코드 리팩토링

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 모든 api 호출부에서 axios → api 인스턴스로 교체

## 🔗 연관된 이슈

> closes #91 
