### PR TITLE
Fix: SideNavigation에 누락된 useBodyScrollLock 및 onClose 적용

### DIFF
--- a/src/components/header/SideNavigation.tsx
+++ b/src/components/header/SideNavigation.tsx
@@ -1,3 +1,4 @@
+import useBodyScrollLock from "@/hooks/useBodyScrollLock";
 import { cn } from "@/libs/utils";
 import { ChevronLeft } from "lucide-react";
 import { Link } from "react-router";
@@ -8,6 +9,8 @@ interface SideNavigationProps {
 }
 
 export default function SideNavigation({ isOpen, onClose }: SideNavigationProps) {
+  useBodyScrollLock(isOpen); // 스크롤 락
+
   return (
     <aside
       className={cn(
@@ -29,6 +32,7 @@ export default function SideNavigation({ isOpen, onClose }: SideNavigationProps)
         <li>
           <Link
             to="/login"
+            onClick={onClose}
             className="inline-flex h-12 w-full items-center px-4 text-lg text-neutral-900 hover:text-green-600"
           >
             로그인
@@ -37,6 +41,7 @@ export default function SideNavigation({ isOpen, onClose }: SideNavigationProps)
         <li>
           <Link
             to="/sign-up"
+            onClick={onClose}
             className="inline-flex h-12 w-full items-center px-4 text-lg text-neutral-900 hover:text-green-600"
           >
             회원가입


### PR DESCRIPTION
## 🚀 PR 요약

> SideNavigation에 스크롤 락과 onClose 추가했습니다.

## ✏️ 변경 유형

- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `useBodyScrollLock` 훅을 SideNavigation에 적용 
(이전에 만들어두고 적용을 안해놨더라구요..!)
- Link 클릭 시 사이드바가 닫히도록 `onClose` 추가


### 스크린 샷


https://github.com/user-attachments/assets/101c0531-ba64-4b9a-9356-58f450271450



## 🔗 연관된 이슈

> closes #99
