### PR TITLE
Feature: 로그인 상태에 따른 Header UI 변경

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,13 +1,13 @@
 import LoggedInHeaderMenu from "@/components/header/LoggedInHeaderMenu";
 import SideNavigation from "@/components/header/SideNavigation";
 import UnLoggedInHeaderMenu from "@/components/header/UnLoggedInHeaderMenu";
+import useAuthStore from "@/hooks/stores/useAuthStore";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import { useEffect, useState } from "react";
 import { Link } from "react-router";
 
 export default function Header() {
-  // 임시 로그인 상태 (추후 변경 예정)
-  const [isLoggedIn] = useState(false);
+  const { isAuthed } = useAuthStore();
   const [isSideNavOpen, setIsSideNavOpen] = useState(false);
 
   // Tailwind의 sm size
@@ -28,7 +28,7 @@ export default function Header() {
             </Link>
           </h1>
 
-          {isLoggedIn ? (
+          {isAuthed ? (
             <LoggedInHeaderMenu />
           ) : (
             <UnLoggedInHeaderMenu isMobile={isMobile} onMenuClick={() => setIsSideNavOpen(true)} />

--- a/src/components/header/LoggedInHeaderMenu.tsx
+++ b/src/components/header/LoggedInHeaderMenu.tsx
@@ -1,8 +1,15 @@
 import Button from "@/components/common/Button";
+import { useLogoutMutation } from "@/hooks/api/auth";
 import { LogOutIcon, User2Icon } from "lucide-react";
 import { Link } from "react-router";
 
 export default function LoggedInHeaderMenu() {
+  const { mutate: logout } = useLogoutMutation();
+
+  const handleLogout = () => {
+    logout();
+  };
+
   return (
     <nav className="flex gap-3">
       {/* 마이페이지 */}
@@ -24,7 +31,12 @@ export default function LoggedInHeaderMenu() {
       >
         <LogOutIcon />
       </Button>
-      <Button variant={"primaryOutline"} size="lg" className="hidden sm:block">
+      <Button
+        variant={"primaryOutline"}
+        size="lg"
+        className="hidden sm:block"
+        onClick={handleLogout}
+      >
         로그아웃
       </Button>
     </nav>

--- a/src/components/header/LoggedInHeaderMenu.tsx
+++ b/src/components/header/LoggedInHeaderMenu.tsx
@@ -7,7 +7,7 @@ export default function LoggedInHeaderMenu() {
     <nav className="flex gap-3">
       {/* 마이페이지 */}
       <Link
-        to="/mypage"
+        to="/my-page"
         className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-green-600 bg-neutral-50 text-green-600 hover:bg-neutral-200 sm:h-14 sm:w-auto"
         aria-label="마이페이지"
       >

--- a/src/hooks/api/auth/useLogoutMutation.ts
+++ b/src/hooks/api/auth/useLogoutMutation.ts
@@ -18,7 +18,7 @@ export default function useLogoutMutation(
       api.post<LogoutResponse>(`${MSW_BASE_URL}/user/logout`).then((res) => res.data),
     onSettled: () => {
       clearAuth();
-      navigate("/login", { replace: true });
+      navigate("/", { replace: true });
     },
     ...options,
   });


### PR DESCRIPTION
## 🚀 PR 요약

> 로그인 상태에 따라 Header UI가 동적으로 변경되도록 구현했습니다.

## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `useAuthStore`를 이용해 `isAuthed` 상태 기반으로 Header UI 분기 처리
- `LoggedInHeaderMenu`에 로그아웃 버튼 연결 (`useLogoutMutation` 사용)
- 로그아웃 시 경로를 `/login` → `/` 으로 수정  

#### 💬 로그아웃 시 경로 수정에 대한 의견
- 이건뭐약은 비로그인 상태로 홈 화면, 검색 등 이용할 수 있으니까, 
사용자 흐름상 홈으로 이동하는 게 자연스럽다고 판단했습니다!
- 개인적으로는 로그아웃 직후 로그인 페이지로 이동하면 다소.. 다시 로그인해!!라는 느낌을 받을 때가 있기도 하구요..! 

### 스크린 샷

https://github.com/user-attachments/assets/984a92de-5827-454d-b430-81b1ded40141

## 🔗 연관된 이슈

> closes #117
