### PR TITLE
Feature: 마이페이지 이미지 검색 목록

### DIFF
--- a/src/components/ImageSearchPillListItem.tsx
+++ b/src/components/ImageSearchPillListItem.tsx
@@ -1,45 +1,65 @@
 import Badge from "@/components/common/Badge";
 import Bookmark from "@/components/common/Bookmark";
+import { MSW_BASE_URL } from "@/constants/url-constants";
+import { api } from "@/libs/axios";
 import { cn } from "@/libs/utils";
+import type {
+  ImageSearchApiRecord,
+  ImageSearchStatus,
+} from "@/types/api-response-types/image-search-types";
 import type { Pill } from "@/types/api-response-types/pill-response-types";
+import { useQuery } from "@tanstack/react-query";
 import { ChevronRightIcon } from "lucide-react";
 import { Link } from "react-router";
-
-// 처리중 | 처리 완료 | 처리 실패
-type ImageSearchStatus = "pending" | "completed" | "failed";
 
 // 각 상태에 대응하는 텍스트
 const statusLabel: Record<ImageSearchStatus, string> = {
   pending: "처리중",
   completed: "처리 완료",
-  failed: "처리 실패",
+  completed_failed: "처리 실패",
 };
 
 // 각 상태에 대응하는 Badge 색상
 const statusVariant: Record<ImageSearchStatus, "secondary" | "primary" | "danger"> = {
   pending: "secondary",
   completed: "primary",
-  failed: "danger",
+  completed_failed: "danger",
 };
 
+// /my_requests 응답의 item_seq를 이용해 의약품 상세 정보 요청
+// - 검색 결과 completed 상태일 때만 호출
+async function fetchPill(itemSeq: string) {
+  const { data } = await api.get<Pill>(`${MSW_BASE_URL}/pills/${itemSeq}`);
+  return data;
+}
+
 type ImageSearchPillListItemProps = {
-  pill: Pill;
-  status?: ImageSearchStatus;
+  record: ImageSearchApiRecord;
   className?: string;
 };
 
 export default function ImageSearchPillListItem({
-  pill,
-  status = "completed", // 임시 기본값
+  record,
   className,
 }: ImageSearchPillListItemProps) {
-  const {
-    item_name: name,
-    efcy_qesitm: description,
-    item_image_url: imageUrl,
-    item_seq: id,
-    is_marked: isMarked,
-  } = pill;
+  const isPending = record.status === "pending";
+  const isCompleted = record.status === "completed" && record.item_seq !== "";
+  const isFailed = record.status === "completed_failed";
+
+  // completed + item_seq 있을 때만 약 조회
+  const itemSeq = isCompleted ? record.item_seq : undefined;
+
+  const { data: pill } = useQuery<Pill>({
+    queryKey: ["pill", itemSeq],
+    queryFn: () => fetchPill(itemSeq as string),
+    enabled: !!itemSeq,
+  });
+
+  function getStatusText() {
+    if (isPending) return "이미지 분석 중입니다.";
+    if (isFailed) return "이미지에서 의약품을 인식할 수 없습니다.";
+    return "";
+  }
 
   return (
     <div
@@ -48,29 +68,41 @@ export default function ImageSearchPillListItem({
         className
       )}
     >
+      {/* 유저가 업로드한 이미지 썸네일 */}
       <img
-        alt={`${name}-image`}
-        src={imageUrl}
-        className="h-20 w-20 object-contain object-center sm:h-24 sm:w-36"
+        src={record.url}
+        alt={record.filename}
+        className="h-20 w-20 object-cover object-center sm:h-24 sm:w-36"
       />
       <div className="flex flex-1 flex-col items-start justify-center gap-2 sm:gap-3">
         <div className="flex w-full items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Badge variant={statusVariant[status]}>{statusLabel[status]}</Badge>
-            <Link
-              to={`/pill/${id}`}
-              aria-label={`${name} 상세페이지`}
-              className="flex items-center gap-0.5"
-            >
-              <span className="text-lg font-normal text-neutral-900 sm:text-2xl sm:font-medium">
-                {name}
+          <div className="flex flex-col gap-3">
+            <Badge variant={statusVariant[record.status]} className="w-fit">
+              {statusLabel[record.status]}
+            </Badge>
+
+            {isCompleted ? (
+              <Link
+                to={`/pill/${record.item_seq}`}
+                aria-label={`${record.item_seq} 상세페이지`}
+                className="flex items-center gap-0.5"
+              >
+                <span className="text-base font-normal text-neutral-900 hover:text-green-600 sm:text-2xl sm:font-medium">
+                  {pill?.item_name}
+                </span>
+                <ChevronRightIcon className="h-6 w-6 text-neutral-400" />
+              </Link>
+            ) : (
+              <span className="text-sm font-normal text-neutral-600 sm:text-base">
+                {getStatusText()}
               </span>
-              <ChevronRightIcon className="h-6 w-6 text-neutral-400" />
-            </Link>
+            )}
           </div>
-          <Bookmark pillId={id} initialState={isMarked} />
+
+          {isCompleted && pill ? (
+            <Bookmark pillId={pill.item_seq} initialState={pill.is_marked} />
+          ) : null}
         </div>
-        <span className="text-lg text-neutral-600">{description}</span>
       </div>
     </div>
   );

--- a/src/components/ImageSearchPillListItem.tsx
+++ b/src/components/ImageSearchPillListItem.tsx
@@ -1,14 +1,11 @@
 import Badge from "@/components/common/Badge";
 import Bookmark from "@/components/common/Bookmark";
-import { MSW_BASE_URL } from "@/constants/url-constants";
-import { api } from "@/libs/axios";
+import useImageSearchPillDetail from "@/hooks/api/my-page/useImageSearchPillDetail";
 import { cn } from "@/libs/utils";
 import type {
   ImageSearchApiRecord,
   ImageSearchStatus,
 } from "@/types/api-response-types/image-search-types";
-import type { Pill } from "@/types/api-response-types/pill-response-types";
-import { useQuery } from "@tanstack/react-query";
 import { ChevronRightIcon } from "lucide-react";
 import { Link } from "react-router";
 
@@ -26,13 +23,6 @@ const statusVariant: Record<ImageSearchStatus, "secondary" | "primary" | "danger
   completed_failed: "danger",
 };
 
-// /my_requests 응답의 item_seq를 이용해 의약품 상세 정보 요청
-// - 검색 결과 completed 상태일 때만 호출
-async function fetchPill(itemSeq: string) {
-  const { data } = await api.get<Pill>(`${MSW_BASE_URL}/pills/${itemSeq}`);
-  return data;
-}
-
 type ImageSearchPillListItemProps = {
   record: ImageSearchApiRecord;
   className?: string;
@@ -48,12 +38,7 @@ export default function ImageSearchPillListItem({
 
   // completed + item_seq 있을 때만 약 조회
   const itemSeq = isCompleted ? record.item_seq : undefined;
-
-  const { data: pill } = useQuery<Pill>({
-    queryKey: ["pill", itemSeq],
-    queryFn: () => fetchPill(itemSeq as string),
-    enabled: !!itemSeq,
-  });
+  const { data: pill } = useImageSearchPillDetail(itemSeq);
 
   function getStatusText() {
     if (isPending) return "이미지 분석 중입니다.";

--- a/src/components/ImageSearchPillListItem.tsx
+++ b/src/components/ImageSearchPillListItem.tsx
@@ -33,7 +33,7 @@ export default function ImageSearchPillListItem({
   className,
 }: ImageSearchPillListItemProps) {
   const isPending = record.status === "pending";
-  const isCompleted = record.status === "completed" && record.item_seq !== "";
+  const isCompleted = record.status === "completed";
   const isFailed = record.status === "completed_failed";
 
   // completed + item_seq 있을 때만 약 조회

--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -20,3 +20,6 @@ export const ACCESS_TOKEN_EXPIRE_SECONDS = 900;
 
 // 회원탈퇴 시 입력 텍스트
 export const DELETE_ACCOUNT_CONFIRM_TEXT = "회원탈퇴";
+
+// 마이페이지 - 이미지 검색 목록 최대 표시 개수
+export const IMAGE_SEARCH_MAX_COUNT = 10;

--- a/src/constants/api-constants.ts
+++ b/src/constants/api-constants.ts
@@ -23,3 +23,6 @@ export const DELETE_ACCOUNT_CONFIRM_TEXT = "회원탈퇴";
 
 // 마이페이지 - 이미지 검색 목록 최대 표시 개수
 export const IMAGE_SEARCH_MAX_COUNT = 10;
+
+// 마이페이지 - 이미지 검색 목록 polling 주기(ms) - 2초
+export const IMAGE_SEARCH_REFETCH_INTERVAL_MS = 2000;

--- a/src/hooks/api/my-page/index.ts
+++ b/src/hooks/api/my-page/index.ts
@@ -1,4 +1,6 @@
 import useNicknameEdit from "@/hooks/api/my-page/useNicknameEdit";
 import usePasswordEdit from "@/hooks/api/my-page/usePasswordEdit";
+import useBookmarkList from "@/hooks/api/my-page/useBookmarkList";
+import useImageSearchList from "@/hooks/api/my-page/useImageSearchList";
 
-export { useNicknameEdit, usePasswordEdit };
+export { useNicknameEdit, usePasswordEdit, useBookmarkList, useImageSearchList };

--- a/src/hooks/api/my-page/useImageSearchList.ts
+++ b/src/hooks/api/my-page/useImageSearchList.ts
@@ -1,0 +1,13 @@
+import { api } from "@/libs/axios";
+import type { ImageSearchApiResponse } from "@/types/api-response-types/image-search-types";
+import { useQuery } from "@tanstack/react-query";
+
+export default function useImageSearchList() {
+  return useQuery<ImageSearchApiResponse>({
+    queryKey: ["mypage", "image-search-list"],
+    queryFn: async () => {
+      const res = await api.get("/my_requests"); // 임시 엔드포인트
+      return res.data;
+    },
+  });
+}

--- a/src/hooks/api/my-page/useImageSearchList.ts
+++ b/src/hooks/api/my-page/useImageSearchList.ts
@@ -1,3 +1,4 @@
+import { MSW_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { ImageSearchApiResponse } from "@/types/api-response-types/image-search-types";
 import { useQuery } from "@tanstack/react-query";
@@ -6,7 +7,7 @@ export default function useImageSearchList() {
   return useQuery<ImageSearchApiResponse>({
     queryKey: ["mypage", "image-search-list"],
     queryFn: async () => {
-      const res = await api.get("/my_requests"); // 임시 엔드포인트
+      const res = await api.get(`${MSW_BASE_URL}/my_requests`);
       return res.data;
     },
   });

--- a/src/hooks/api/my-page/useImageSearchList.ts
+++ b/src/hooks/api/my-page/useImageSearchList.ts
@@ -1,4 +1,7 @@
-import { IMAGE_SEARCH_MAX_COUNT } from "@/constants/api-constants";
+import {
+  IMAGE_SEARCH_MAX_COUNT,
+  IMAGE_SEARCH_REFETCH_INTERVAL_MS,
+} from "@/constants/api-constants";
 import { MSW_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { ImageSearchApiResponse } from "@/types/api-response-types/image-search-types";
@@ -21,7 +24,7 @@ export default function useImageSearchList() {
     refetchInterval: (query) => {
       const records = query.state.data?.records;
       const hasPending = records?.some((record) => record.status === "pending");
-      return hasPending ? 2000 : false;
+      return hasPending ? IMAGE_SEARCH_REFETCH_INTERVAL_MS : false;
     },
 
     // 필요 시 백그라운드에서도 일정 주기로 API 호출(폴링) 유지

--- a/src/hooks/api/my-page/useImageSearchList.ts
+++ b/src/hooks/api/my-page/useImageSearchList.ts
@@ -10,5 +10,17 @@ export default function useImageSearchList() {
       const res = await api.get(`${MSW_BASE_URL}/my_requests`);
       return res.data;
     },
+
+    // 이미지 분석 상태가 pending인 항목이 있을 경우에만 2초 주기로 자동 refetch
+    // - 모든 항목이 완료되면(refetchInterval = false) 폴링 중단
+    refetchInterval: (query) => {
+      const records = query.state.data?.records;
+      const hasPending = records?.some((record) => record.status === "pending");
+
+      return hasPending ? 2000 : false;
+    },
+
+    // 필요 시 백그라운드에서도 일정 주기로 API 호출(폴링) 유지
+    // refetchIntervalInBackground: true,
   });
 }

--- a/src/hooks/api/my-page/useImageSearchList.ts
+++ b/src/hooks/api/my-page/useImageSearchList.ts
@@ -1,3 +1,4 @@
+import { IMAGE_SEARCH_MAX_COUNT } from "@/constants/api-constants";
 import { MSW_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { ImageSearchApiResponse } from "@/types/api-response-types/image-search-types";
@@ -8,7 +9,11 @@ export default function useImageSearchList() {
     queryKey: ["mypage", "image-search-list"],
     queryFn: async () => {
       const res = await api.get(`${MSW_BASE_URL}/my_requests`);
-      return res.data;
+      const data = res.data;
+
+      // 리스트 10개만 노출 (명세 참고)
+      data.records = data.records.slice(0, IMAGE_SEARCH_MAX_COUNT);
+      return data;
     },
 
     // 이미지 분석 상태가 pending인 항목이 있을 경우에만 2초 주기로 자동 refetch
@@ -16,7 +21,6 @@ export default function useImageSearchList() {
     refetchInterval: (query) => {
       const records = query.state.data?.records;
       const hasPending = records?.some((record) => record.status === "pending");
-
       return hasPending ? 2000 : false;
     },
 

--- a/src/hooks/api/my-page/useImageSearchPillDetail.ts
+++ b/src/hooks/api/my-page/useImageSearchPillDetail.ts
@@ -1,0 +1,19 @@
+import { MSW_BASE_URL } from "@/constants/url-constants";
+import { api } from "@/libs/axios";
+import type { PillDetail } from "@/types/api-response-types/pill-response-types";
+import { useQuery } from "@tanstack/react-query";
+
+// /my_requests 응답의 item_seq를 이용해 의약품 상세 정보 요청
+// - 검색 결과 completed 상태일 때만 호출
+async function fetchPillDetail(itemSeq: string) {
+  const { data } = await api.get<PillDetail>(`${MSW_BASE_URL}/pills/${itemSeq}`);
+  return data;
+}
+
+export default function useImageSearchPillDetail(itemSeq?: string) {
+  return useQuery<PillDetail>({
+    queryKey: ["pill", "image-search", itemSeq],
+    queryFn: () => fetchPillDetail(itemSeq as string),
+    enabled: !!itemSeq,
+  });
+}

--- a/src/mocks/data/pill-image-search.ts
+++ b/src/mocks/data/pill-image-search.ts
@@ -1,0 +1,23 @@
+export const mockPillImageSearchRecords = [
+  {
+    filename: "pill_pending.jpg",
+    url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
+    status: "pending",
+    created_at: "25111310121532",
+    item_seq: "",
+  },
+  {
+    filename: "pill_ok.jpg",
+    url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
+    status: "completed",
+    created_at: "25111210112152",
+    item_seq: "100001", // 타이레놀
+  },
+  {
+    filename: "pill_fail.jpg",
+    url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
+    status: "completed_failed",
+    created_at: "25111110112152",
+    item_seq: "",
+  },
+];

--- a/src/mocks/handlers/my-page-handlers.ts
+++ b/src/mocks/handlers/my-page-handlers.ts
@@ -37,4 +37,53 @@ const getBookmarks = http.get(`${MSW_BASE_URL}/bookmark`, () => {
   return HttpResponse.json(response, { status: 200 });
 });
 
-export const myPageHandlers = [patchNickname, patchPassword, getBookmarks];
+// 이미지 검색 요청 목록
+const getImageSearchList = http.get(`${MSW_BASE_URL}/my_requests`, () => {
+  return HttpResponse.json(
+    {
+      records: [
+        {
+          filename: "pill_pending.jpg",
+          url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
+          status: "pending",
+          item_seq: "",
+        },
+        {
+          filename: "pill_ok.jpg",
+          url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
+          status: "completed",
+          item_seq: "100001", // 타이레놀
+        },
+        {
+          filename: "pill_fail.jpg",
+          url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
+          status: "completed_failed",
+          item_seq: "",
+        },
+      ],
+    },
+    { status: 200 }
+  );
+});
+
+// 이미지 검색 목록에 약 이름/북마크 반영용 핸들러
+// - mockPills에서 해당 item_seq의 의약품 정보 반환
+// - ImageSearchPillListItem 컴포넌트에서 이미지 검색 결과가 completed 상태일 때 참조됨
+const getPillDetail = http.get(`${MSW_BASE_URL}/pills/:itemSeq`, ({ params }) => {
+  const { itemSeq } = params as { itemSeq: string };
+  const pill = mockPills.find((p) => p.item_seq === itemSeq);
+
+  if (!pill) {
+    return HttpResponse.json({ error: "요청한 의약품의 정보가 없습니다." }, { status: 404 });
+  }
+
+  return HttpResponse.json(pill, { status: 200 });
+});
+
+export const myPageHandlers = [
+  patchNickname,
+  patchPassword,
+  getBookmarks,
+  getImageSearchList,
+  getPillDetail,
+];

--- a/src/mocks/handlers/my-page-handlers.ts
+++ b/src/mocks/handlers/my-page-handlers.ts
@@ -1,6 +1,5 @@
 import { MSW_BASE_URL } from "@/constants/url-constants";
 import { mockPills } from "@/mocks/data/pill-data";
-import { mockPillImageSearchRecords } from "@/mocks/data/pill-image-search";
 import { http, HttpResponse } from "msw";
 
 const BOOKMARK_LIMIT = 20;
@@ -38,34 +37,4 @@ const getBookmarks = http.get(`${MSW_BASE_URL}/bookmark`, () => {
   return HttpResponse.json(response, { status: 200 });
 });
 
-// 이미지 검색 요청 목록
-const getImageSearchList = http.get(`${MSW_BASE_URL}/my_requests`, () => {
-  return HttpResponse.json(
-    {
-      records: mockPillImageSearchRecords,
-    },
-    { status: 200 }
-  );
-});
-
-// 이미지 검색 목록에 약 이름/북마크 반영용 핸들러
-// - mockPills에서 해당 item_seq의 의약품 정보 반환
-// - ImageSearchPillListItem 컴포넌트에서 이미지 검색 결과가 completed 상태일 때 참조됨
-const getPillDetail = http.get(`${MSW_BASE_URL}/pills/:itemSeq`, ({ params }) => {
-  const { itemSeq } = params as { itemSeq: string };
-  const pill = mockPills.find((p) => p.item_seq === itemSeq);
-
-  if (!pill) {
-    return HttpResponse.json({ error: "요청한 의약품의 정보가 없습니다." }, { status: 404 });
-  }
-
-  return HttpResponse.json(pill, { status: 200 });
-});
-
-export const myPageHandlers = [
-  patchNickname,
-  patchPassword,
-  getBookmarks,
-  getImageSearchList,
-  getPillDetail,
-];
+export const myPageHandlers = [patchNickname, patchPassword, getBookmarks];

--- a/src/mocks/handlers/my-page-handlers.ts
+++ b/src/mocks/handlers/my-page-handlers.ts
@@ -1,5 +1,6 @@
 import { MSW_BASE_URL } from "@/constants/url-constants";
 import { mockPills } from "@/mocks/data/pill-data";
+import { mockPillImageSearchRecords } from "@/mocks/data/pill-image-search";
 import { http, HttpResponse } from "msw";
 
 const BOOKMARK_LIMIT = 20;
@@ -41,26 +42,7 @@ const getBookmarks = http.get(`${MSW_BASE_URL}/bookmark`, () => {
 const getImageSearchList = http.get(`${MSW_BASE_URL}/my_requests`, () => {
   return HttpResponse.json(
     {
-      records: [
-        {
-          filename: "pill_pending.jpg",
-          url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
-          status: "pending",
-          item_seq: "",
-        },
-        {
-          filename: "pill_ok.jpg",
-          url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
-          status: "completed",
-          item_seq: "100001", // 타이레놀
-        },
-        {
-          filename: "pill_fail.jpg",
-          url: "https://plus.unsplash.com/premium_photo-1668487826871-2f2cac23ad56?ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJTk1JUJEfGVufDB8fDB8fHww&auto=format&fit=crop&q=60&w=900",
-          status: "completed_failed",
-          item_seq: "",
-        },
-      ],
+      records: mockPillImageSearchRecords,
     },
     { status: 200 }
   );

--- a/src/mocks/handlers/pill-image-handlers.ts
+++ b/src/mocks/handlers/pill-image-handlers.ts
@@ -1,4 +1,5 @@
 import { MSW_BASE_URL } from "@/constants/url-constants";
+import { mockPillImageSearchRecords } from "@/mocks/data/pill-image-search";
 import { http, HttpResponse } from "msw";
 
 const postPillImage = http.post(`${MSW_BASE_URL}/pills/image`, async ({ request }) => {
@@ -14,4 +15,14 @@ const postPillImage = http.post(`${MSW_BASE_URL}/pills/image`, async ({ request 
   return new HttpResponse(null, { status: 200 });
 });
 
-export const pillImageHandlers = [postPillImage];
+// 이미지 검색 요청 목록
+const getImageSearchList = http.get(`${MSW_BASE_URL}/my_requests`, () => {
+  return HttpResponse.json(
+    {
+      records: mockPillImageSearchRecords,
+    },
+    { status: 200 }
+  );
+});
+
+export const pillImageHandlers = [postPillImage, getImageSearchList];

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -2,21 +2,28 @@ import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
 import Loading from "@/components/common/Loading";
 import Tab from "@/components/common/Tab";
+import ImageSearchPillListItem from "@/components/ImageSearchPillListItem";
 import Modal from "@/components/Modal";
 import PillListItem from "@/components/PillListItem";
 import { DELETE_ACCOUNT_CONFIRM_TEXT } from "@/constants/api-constants";
 import { useDeleteAccount } from "@/hooks/api/auth";
+import { useImageSearchList } from "@/hooks/api/my-page";
 import useBookmarkList from "@/hooks/api/my-page/useBookmarkList";
 import useAuthStore from "@/hooks/stores/useAuthStore";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 export default function Mypage() {
+  // 북마크 목록
   const { data, isPending: isBookmarkListPending } = useBookmarkList();
   const bookmarkedPills = data?.pills ?? [];
+
+  // 이미지 검색 목록
+  const { data: imageData } = useImageSearchList();
+  const imageSearchList = imageData?.records ?? [];
+
   const { user, clearAuth } = useAuthStore();
   const navigate = useNavigate();
-
   const [activeTab, setActiveTab] = useState<"bookmark" | "image-search">("bookmark");
 
   const activeTitleTab = {
@@ -101,8 +108,12 @@ export default function Mypage() {
                   label: "이미지 검색",
                   content: (
                     <div className="grid w-full gap-5">
-                      <p>이미지 검색</p>
-                      {/* 이미지 검색 리스트 */}
+                      {imageSearchList.length === 0 && (
+                        <p className="text-center text-neutral-500">이미지 검색 내역이 없습니다.</p>
+                      )}
+                      {imageSearchList.map((record, index) => (
+                        <ImageSearchPillListItem key={`${imageData}-${index}`} record={record} />
+                      ))}
                     </div>
                   ),
                   activeClassName: "rounded-2xl",

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -111,8 +111,8 @@ export default function Mypage() {
                       {imageSearchList.length === 0 && (
                         <p className="text-center text-neutral-500">이미지 검색 내역이 없습니다.</p>
                       )}
-                      {imageSearchList.map((record, index) => (
-                        <ImageSearchPillListItem key={`${imageData}-${index}`} record={record} />
+                      {imageSearchList.map((record) => (
+                        <ImageSearchPillListItem key={record.created_at} record={record} />
                       ))}
                     </div>
                   ),

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -10,6 +10,7 @@ import { useDeleteAccount } from "@/hooks/api/auth";
 import { useImageSearchList } from "@/hooks/api/my-page";
 import useBookmarkList from "@/hooks/api/my-page/useBookmarkList";
 import useAuthStore from "@/hooks/stores/useAuthStore";
+import type { ImageSearchApiRecord } from "@/types/api-response-types/image-search-types";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 
@@ -111,7 +112,7 @@ export default function Mypage() {
                       {imageSearchList.length === 0 && (
                         <p className="text-center text-neutral-500">이미지 검색 내역이 없습니다.</p>
                       )}
-                      {imageSearchList.map((record) => (
+                      {imageSearchList.map((record: ImageSearchApiRecord) => (
                         <ImageSearchPillListItem key={record.created_at} record={record} />
                       ))}
                     </div>

--- a/src/types/api-response-types/image-search-types.ts
+++ b/src/types/api-response-types/image-search-types.ts
@@ -5,13 +5,21 @@ export type ImageSearchStatus = "pending" | "completed" | "completed_failed";
 // - pending: 처리 중 → item_seq는 비어 있음
 // - completed: 처리 완료 → item_seq는 매핑표에 존재하는 경우 약 고유번호
 // - completed_failed: 처리 실패 → item_seq는 비어 있음
-export interface ImageSearchApiRecord {
+export interface ImageSearchApiRecordBase {
   filename: string;
   url: string;
-  status: ImageSearchStatus;
   created_at: string;
-  item_seq: string | "";
 }
+
+export type ImageSearchApiRecord =
+  | (ImageSearchApiRecordBase & {
+      status: "pending" | "completed_failed";
+      item_seq: "";
+    })
+  | (ImageSearchApiRecordBase & {
+      status: "completed";
+      item_seq: string;
+    });
 
 // 이미지 검색 목록 API 응답
 // - records: 최근 업로드된 이미지 검색 내역 최대 10개 (명세 참고)

--- a/src/types/api-response-types/image-search-types.ts
+++ b/src/types/api-response-types/image-search-types.ts
@@ -1,0 +1,18 @@
+// 이미지 검색 상태 (처리중 | 처리 완료 | 처리 실패)
+export type ImageSearchStatus = "pending" | "completed" | "completed_failed";
+
+// 업로드된 이미지 1건에 대한 타입
+// - pending: 처리 중 → item_seq는 비어 있음
+// - completed: 처리 완료 → item_seq는 매핑표에 존재하는 경우 약 고유번호
+// - completed_failed: 처리 실패 → item_seq는 비어 있음
+export interface ImageSearchApiRecord {
+  filename: string;
+  url: string;
+  status: ImageSearchStatus;
+  item_seq: string | "";
+}
+
+// 이미지 검색 목록 API 응답
+export interface ImageSearchApiResponse {
+  records: ImageSearchApiRecord[];
+}

--- a/src/types/api-response-types/image-search-types.ts
+++ b/src/types/api-response-types/image-search-types.ts
@@ -9,6 +9,7 @@ export interface ImageSearchApiRecord {
   filename: string;
   url: string;
   status: ImageSearchStatus;
+  created_at: string;
   item_seq: string | "";
 }
 

--- a/src/types/api-response-types/image-search-types.ts
+++ b/src/types/api-response-types/image-search-types.ts
@@ -13,6 +13,7 @@ export interface ImageSearchApiRecord {
 }
 
 // 이미지 검색 목록 API 응답
+// - records: 최근 업로드된 이미지 검색 내역 최대 10개 (명세 참고)
 export interface ImageSearchApiResponse {
   records: ImageSearchApiRecord[];
 }


### PR DESCRIPTION
## 🚀 PR 요약

> 마이페이지 이미지 검색 목록

## ✏️ 변경 유형

- feat: 새로운 기능 추가
- refactor: 코드 리팩토링

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `ImageSearchPillListItem` 컴포넌트 상태별 렌더링 처리
  - pending / completed / completed_failed 조건 분기  
  - completed + item_seq 존재 시만 의약품 상세 정보 조회
- `useImageSearchList`에 폴링 적용
  - 목록 안에 `pending` 상태가 하나라도 있으면 2초마다 자동 refetch  
  - 모든 항목 완료 시 폴링 자동 중단  
- 이미지 검색 목록 최대 10개 제한 (`IMAGE_SEARCH_MAX_COUNT` 적용)
- key 값 `created_at`으로 적용 (유니크 키 값)

<br>

### refetchInterval / refetchIntervalInBackground
```ts
    refetchInterval: (query) => {
      const records = query.state.data?.records;
      const hasPending = records?.some((record) => record.status === "pending");
      return hasPending ? 2000 : false;
    },

    // 필요 시 백그라운드에서도 일정 주기로 API 호출(폴링) 유지
    // refetchIntervalInBackground: true,
```
`refetchInterval` 지정한 주기(ms)마다 자동으로 refetch(재요청)
- 숫자 입력 → 해당 ms마다 계속 재요청
- 함수 입력 → 조건에 따라 ms 또는 false 반환
- false면 자동 폴링 중단

`refetchIntervalInBackground` 
- true면 백그라운드여도 폴링 유지
- 기본은 false라서 백그라운드에선 폴링 멈춤
(백그라운드란? 브라우저 탭이 활성 상태가 아닐 때를 의미  
즉, 브라우저 화면에 보여지지 않는 상태가 백그라운드)

<br>

응답 안에 pending인 항목이 하나라도 있으면 2초마다 자동으로 /my_requests API 재요청합니다.
모든 항목이 completed나 completed_failed 상태라면 → false 반환 → 폴링 중지

즉, 아직 분석중인 이미지가 있으면 2초마다 최신 상태를 받아오고, 모두 처리 완료가 되면 자동으로 멈춤!

백그라운드에서는 기본값(false)을 유지하도록 했습니다. 
탭 전환 중에는 폴링 중단하고, 사용자가 다시 돌아오면 최신 데이터 자동 갱신되도록 했습니다.

### 참고 
- [TanStack Query(React) - 공식문서 한국어 번역 깃허브](https://github.com/ssi02014/react-query-tutorial)
- [TanStack Query v5](https://tanstack.com/query/latest/docs/framework/react/reference/useQuery)
- [refetchInterval를 통한 데이터 실시간 동기화](https://no2jfamily.tistory.com/121)
- [useQuery 필요할 때만 데이터 로드하기](https://kokoball-dev.tistory.com/64)

### 스크린 샷

https://github.com/user-attachments/assets/7a469349-e2f6-4c40-b507-021824012ba7


## 🔗 연관된 이슈

> closes #128
