### PR TITLE
fix: 모바일 Header 로그아웃 버튼 onClick 누락 수정

### DIFF
--- a/src/components/header/LoggedInHeaderMenu.tsx
+++ b/src/components/header/LoggedInHeaderMenu.tsx
@@ -28,6 +28,7 @@ export default function LoggedInHeaderMenu() {
         size="sm"
         className="inline-flex h-10 w-10 items-center justify-center p-0 text-green-600 sm:hidden"
         aria-label="로그아웃"
+        onClick={handleLogout}
       >
         <LogOutIcon />
       </Button>


### PR DESCRIPTION
## 🚀 PR 요약

> 모바일 환경에서 Header 로그아웃 버튼에 onClick 누락된 부분을 수정했습니다.

## ✏️ 변경 유형

- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 모바일(sm 미만) 환경에서 표시되는 로그아웃 아이콘 버튼에 onClick={handleLogout} 추가
이전에 제가 로그아웃 버튼에는 적용을 했는데, 모바일 아이콘 로그아웃 버튼에는 적용을 안했네요.. 주의하겠습니다!

### 스크린 샷

https://github.com/user-attachments/assets/89ebfba4-3e22-4e9e-a6a5-0c6d97ebdfd8


## 🔗 연관된 이슈

> closes #139
