### PR TITLE
Fix: 불필요한 RouteGuard 토스트 해결

### DIFF
--- a/src/components/route-guard/ProtectedRoute.tsx
+++ b/src/components/route-guard/ProtectedRoute.tsx
@@ -7,13 +7,21 @@ export default function ProtectedRoute() {
   const { triggerToast } = useToast();
 
   if (!isAuthed) {
-    triggerToast(
-      "error",
-      "비로그인 상태 접근 제한",
-      "해당 페이지는 비로그인 상태에서 접근 할 수 없습니다."
-    );
+    const justLoggedOut = sessionStorage.getItem("justLoggedOut");
 
-    return <Navigate to="/login" replace />;
+    if (justLoggedOut) {
+      sessionStorage.removeItem("justLoggedOut");
+    } else {
+      triggerToast(
+        "error",
+        "비로그인 상태 접근 제한",
+        "해당 페이지는 비로그인 상태에서 접근 할 수 없습니다."
+      );
+
+      return <Navigate to="/login" replace />;
+    }
+
+    return <Outlet />;
   }
 
   return (

--- a/src/components/route-guard/ProtectedRoute.tsx
+++ b/src/components/route-guard/ProtectedRoute.tsx
@@ -1,3 +1,4 @@
+import { JUST_LOGGED_OUT } from "@/constants/key-constants";
 import useAuthStore from "@/hooks/stores/useAuthStore";
 import useToast from "@/hooks/useToast";
 import { Navigate, Outlet } from "react-router";
@@ -7,10 +8,10 @@ export default function ProtectedRoute() {
   const { triggerToast } = useToast();
 
   if (!isAuthed) {
-    const justLoggedOut = sessionStorage.getItem("justLoggedOut");
+    const justLoggedOut = sessionStorage.getItem(JUST_LOGGED_OUT);
 
     if (justLoggedOut) {
-      sessionStorage.removeItem("justLoggedOut");
+      sessionStorage.removeItem(JUST_LOGGED_OUT);
     } else {
       triggerToast(
         "error",

--- a/src/components/route-guard/PublicRoute.tsx
+++ b/src/components/route-guard/PublicRoute.tsx
@@ -11,15 +11,17 @@ export default function PublicRoute() {
 
     if (justLoggedIn) {
       sessionStorage.removeItem("justLoggedIn");
+
+      return <Outlet />;
     } else {
       triggerToast(
         "error",
         "로그인 상태 접근 제한",
         "해당 페이지는 로그인 상태에서 접근 할 수 없습니다."
       );
-    }
 
-    return <Navigate to="/" replace />;
+      return <Navigate to="/" replace />;
+    }
   }
 
   return (

--- a/src/components/route-guard/PublicRoute.tsx
+++ b/src/components/route-guard/PublicRoute.tsx
@@ -7,11 +7,17 @@ export default function PublicRoute() {
   const { triggerToast } = useToast();
 
   if (isAuthed) {
-    triggerToast(
-      "error",
-      "로그인 상태 접근 제한",
-      "해당 페이지는 로그인 상태에서 접근 할 수 없습니다."
-    );
+    const justLoggedIn = sessionStorage.getItem("justLoggedIn");
+
+    if (justLoggedIn) {
+      sessionStorage.removeItem("justLoggedIn");
+    } else {
+      triggerToast(
+        "error",
+        "로그인 상태 접근 제한",
+        "해당 페이지는 로그인 상태에서 접근 할 수 없습니다."
+      );
+    }
 
     return <Navigate to="/" replace />;
   }

--- a/src/components/route-guard/PublicRoute.tsx
+++ b/src/components/route-guard/PublicRoute.tsx
@@ -1,3 +1,4 @@
+import { JUST_LOGGED_IN } from "@/constants/key-constants";
 import useAuthStore from "@/hooks/stores/useAuthStore";
 import useToast from "@/hooks/useToast";
 import { Navigate, Outlet } from "react-router";
@@ -7,10 +8,10 @@ export default function PublicRoute() {
   const { triggerToast } = useToast();
 
   if (isAuthed) {
-    const justLoggedIn = sessionStorage.getItem("justLoggedIn");
+    const justLoggedIn = sessionStorage.getItem(JUST_LOGGED_IN);
 
     if (justLoggedIn) {
-      sessionStorage.removeItem("justLoggedIn");
+      sessionStorage.removeItem(JUST_LOGGED_IN);
 
       return <Outlet />;
     } else {

--- a/src/constants/key-constants.ts
+++ b/src/constants/key-constants.ts
@@ -1,0 +1,3 @@
+export const JUST_LOGGED_IN = "justLoggedIn";
+
+export const JUST_LOGGED_OUT = "justLoggedOut";

--- a/src/hooks/api/auth/useLogoutMutation.ts
+++ b/src/hooks/api/auth/useLogoutMutation.ts
@@ -18,6 +18,7 @@ export default function useLogoutMutation(
       api.post<LogoutResponse>(`${MSW_BASE_URL}/user/logout`).then((res) => res.data),
     onSettled: () => {
       clearAuth();
+      sessionStorage.setItem("justLoggedOut", "true");
       navigate("/", { replace: true });
     },
     ...options,

--- a/src/hooks/api/auth/useLogoutMutation.ts
+++ b/src/hooks/api/auth/useLogoutMutation.ts
@@ -5,6 +5,7 @@ import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
 import { useNavigate } from "react-router";
 import { MSW_BASE_URL } from "@/constants/url-constants";
+import { JUST_LOGGED_OUT } from "@/constants/key-constants";
 
 export default function useLogoutMutation(
   options?: UseMutationOptions<LogoutResponse, AxiosError>
@@ -18,7 +19,7 @@ export default function useLogoutMutation(
       api.post<LogoutResponse>(`${MSW_BASE_URL}/user/logout`).then((res) => res.data),
     onSettled: () => {
       clearAuth();
-      sessionStorage.setItem("justLoggedOut", "true");
+      sessionStorage.setItem(JUST_LOGGED_OUT, "true");
       navigate("/", { replace: true });
     },
     ...options,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,10 +18,10 @@ const root = createRoot(document.getElementById("root")!);
 
 enableMocking().then(() => {
   root.render(
-    //<StrictMode>
-    <Providers>
-      <App />
-    </Providers>
-    //</StrictMode>
+    <StrictMode>
+      <Providers>
+        <App />
+      </Providers>
+    </StrictMode>
   );
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,10 +18,10 @@ const root = createRoot(document.getElementById("root")!);
 
 enableMocking().then(() => {
   root.render(
-    <StrictMode>
-      <Providers>
-        <App />
-      </Providers>
-    </StrictMode>
+    //<StrictMode>
+    <Providers>
+      <App />
+    </Providers>
+    //</StrictMode>
   );
 });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import Input from "@/components/common/Input";
 import Loading from "@/components/common/Loading";
 import GoogleButton from "@/components/social-login-button/GoogleButton";
 import KakaoButton from "@/components/social-login-button/KakaoButton";
+import { JUST_LOGGED_IN } from "@/constants/key-constants";
 import { useLoginMutation } from "@/hooks/api/auth";
 import useAuthStore from "@/hooks/stores/useAuthStore";
 import { loginSchema, type LoginSchema } from "@/schema/auth-schema";
@@ -39,7 +40,7 @@ export default function Login() {
         user: data.user,
         accessToken: data.tokens.access_token,
       });
-      sessionStorage.setItem("justLoggedIn", "true");
+      sessionStorage.setItem(JUST_LOGGED_IN, "true");
       navigate("/", { replace: true });
     },
     onError: (error) => {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -39,6 +39,7 @@ export default function Login() {
         user: data.user,
         accessToken: data.tokens.access_token,
       });
+      sessionStorage.setItem("justLoggedIn", "true");
       navigate("/", { replace: true });
     },
     onError: (error) => {


### PR DESCRIPTION
## 🚀 PR 요약

> 불필요한 RouteGuard 토스트 해결

## ✏️ 변경 유형

- fix: 버그 수정


## 🗒️ 상세 내용 (선택)

### 작업 사항

- justLoggedIn 및 justLoggedOut 플래그를 이용해 로그인 및 로그아웃 직후 RouteGuard와의 충돌 해결

### 참고 사항

- StrictMode가 켜져있으면 개발환경에선 2번 렌더링해 여전히 불필요한 토스트가 실행됩니다.
- 아래 테스트 영상은 임시로 StrictMode를 꺼두고 실행했습니다.
- 배포환경에서도 잘 작동하는지 테스트 필요합니다.

### 스크린 샷


https://github.com/user-attachments/assets/eb97ca8f-7733-440c-b6fd-bcb13d6010c6


https://github.com/user-attachments/assets/af7172b0-fac0-43bb-9a8a-8407f9736145


## 🔗 연관된 이슈

> closes #137 
