### PR TITLE
Feature: 의약품 리스트 및 검색 실제 api 연결

### DIFF
--- a/src/components/PillListItem.tsx
+++ b/src/components/PillListItem.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/libs/utils";
 import type { Pill } from "@/types/api-response-types/pill-response-types";
 import { ChevronRightIcon } from "lucide-react";
 import { Link } from "react-router";
+import defautPillImage from "@/assets/images/small_image.jpg";
 
 interface PillListItemProps {
   pill: Pill;
@@ -27,7 +28,7 @@ export default function PillListItem({ className, pill }: PillListItemProps) {
     >
       <img
         alt={`${name}-image`}
-        src={imageUrl}
+        src={imageUrl || defautPillImage}
         className="h-20 w-20 object-contain object-center sm:h-24 sm:w-36"
       />
       <div className="flex flex-1 flex-col items-start justify-center gap-2 sm:gap-3">

--- a/src/hooks/api/useInfinitePillList.ts
+++ b/src/hooks/api/useInfinitePillList.ts
@@ -1,5 +1,5 @@
 import { PILL_LIST_PAGE_LIMIT, PILL_SEARCH_OPTION_MAP } from "@/constants/api-constants";
-import { MSW_BASE_URL } from "@/constants/url-constants";
+import { API_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { PillList } from "@/types/api-response-types/pill-response-types";
 import type { pillSearchOptionFrontend } from "@/types/types";
@@ -35,7 +35,7 @@ export default function useInfinitePillList(
 
         const trimmedValue = queryParamValue.trim();
 
-        const res = await api.get(`${MSW_BASE_URL}/pills/search`, {
+        const res = await api.get(`${API_BASE_URL}/pills/search`, {
           params: {
             page: pageParam,
             [PILL_SEARCH_OPTION_MAP[queryParamKey]]: trimmedValue,
@@ -45,7 +45,7 @@ export default function useInfinitePillList(
         return res.data;
       } else {
         //검색어가 없을 때
-        const res = await api.get(`${MSW_BASE_URL}/pills`, {
+        const res = await api.get(`${API_BASE_URL}/pills`, {
           params: {
             page: pageParam,
           },

--- a/src/pages/PillList.tsx
+++ b/src/pages/PillList.tsx
@@ -13,6 +13,7 @@ import type { pillSearchOptionFrontend } from "@/types/types";
 import useAuthStore from "@/hooks/stores/useAuthStore";
 import useToast from "@/hooks/useToast";
 import Loading from "@/components/common/Loading";
+import { AxiosError } from "axios";
 
 const SELECT_OPTIONS: Option[] = [
   {
@@ -28,6 +29,8 @@ const SELECT_OPTIONS: Option[] = [
     text: "효능",
   },
 ];
+
+const MAX_API_FAILURE_COUNT = 3;
 
 export default function PillList() {
   const { queryParamKey, queryParamValue, setQueryParamKey } = usePillSearchStore();
@@ -56,8 +59,16 @@ export default function PillList() {
     return { queryParamKey, queryParamValue };
   }, [queryParamKey, queryParamValue]);
 
-  const { data, isPending, isError, isFetchingNextPage, hasNextPage, fetchNextPage } =
-    useInfinitePillList(pillSearchParam);
+  const { data, isPending, isError, isFetchingNextPage, hasNextPage, fetchNextPage, error } =
+    useInfinitePillList(pillSearchParam, {
+      retry: (failureCount, error) => {
+        if (error instanceof AxiosError && error.status === 404) {
+          return false;
+        }
+
+        return failureCount <= MAX_API_FAILURE_COUNT;
+      },
+    });
 
   const handleObserverIntersect = () => {
     if (hasNextPage) {
@@ -111,7 +122,10 @@ export default function PillList() {
             }
 
             if (isError || !data) {
-              //TODO: 에러 코드별 분기 처리
+              if (error instanceof AxiosError && error.status === 404) {
+                return <span>해당 검색 결과 내역이 없습니다.</span>;
+              }
+
               return (
                 <span>데이터를 가져오는데 문제가 발생했습니다. 잠시 후 다시 시도해주세요.</span>
               );


### PR DESCRIPTION
## 🚀 PR 요약

> 의약품 리스트 및 검색 실제 api 연결
## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 의약품 리스트 및 검색 실제 api 연결
- 404 에러 핸들링
- 이미지 url 없을 시 default 이미지 보여주기

### 참고 사항

- default 이미지는 추후 로고로 변경

### 스크린 샷

+ 기본
<img width="400" alt="Screenshot 2025-11-17 at 2 40 49 PM" src="https://github.com/user-attachments/assets/e0c81478-e9f5-4434-8572-dc4f3f2cf7db" />

+ 검색 결과
<img width="400" alt="Screenshot 2025-11-17 at 2 41 40 PM" src="https://github.com/user-attachments/assets/884f164e-715c-4c22-943c-c9defff7b248" />

+ 404 에러 (검색 결과 없음)
<img width="400" alt="Screenshot 2025-11-17 at 2 42 14 PM" src="https://github.com/user-attachments/assets/b22b5b74-ef9f-4b11-9df9-a730ee9b5519" />


## 🔗 연관된 이슈

> closes #156
