### PR TITLE
Chore: 개발환경 https 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 # Environment variables
 .env
 .env.*
+
+# https 인증서
+localhost.pem
+localhost-key.pem

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:http": "FORCE_HTTP=true vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,10 +8,14 @@ import fs from "fs";
 export default defineConfig(({ mode }) => {
   const isDev = mode === "development";
 
+  const forceHttp = process.env.FORCE_HTTP === "true";
+
   const keyPath = path.resolve(__dirname, "localhost-key.pem");
   const certPath = path.resolve(__dirname, "localhost.pem");
 
   const hasHttpsCerts = fs.existsSync(keyPath) && fs.existsSync(certPath);
+
+  const useHttps = !forceHttp && hasHttpsCerts;
 
   return {
     plugins: [react(), tailwindcss()],
@@ -24,7 +28,7 @@ export default defineConfig(({ mode }) => {
       ? {
           host: "localhost",
           port: 5173,
-          ...(hasHttpsCerts
+          ...(useHttps
             ? {
                 https: {
                   key: fs.readFileSync(keyPath),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,37 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import fs from "fs";
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const isDev = mode === "development";
+
+  const keyPath = path.resolve(__dirname, "localhost-key.pem");
+  const certPath = path.resolve(__dirname, "localhost.pem");
+
+  const hasHttpsCerts = fs.existsSync(keyPath) && fs.existsSync(certPath);
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
+    server: isDev
+      ? {
+          host: "localhost",
+          port: 5173,
+          ...(hasHttpsCerts
+            ? {
+                https: {
+                  key: fs.readFileSync(keyPath),
+                  cert: fs.readFileSync(certPath),
+                },
+              }
+            : {}),
+        }
+      : undefined,
+  };
 });


### PR DESCRIPTION
## 🚀 PR 요약

> 개발환경 https 설정

## ✏️ 변경 유형

- chore: 기타 변경사항

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 개발환경 https 설정

### 참고 사항

- 아래 방법에 따라 인증서를 만들어야 https로 실행할 수 있습니다.
- 기본적으로 `npm run dev`를 실행하면 인증서가 있는 경우 https, 없는 경우 http로 실행합니다.
- 인증서가 있는데 http로 실행하고 싶은 경우 아래 명령을 사용하면 됩니다.
  - `npm run dev:http`


## 로컬에서 https로 여는 법

### 1. mkcert 설치

- 아래 링크 참고해서 다운로드
https://github.com/FiloSottile/mkcert

### 2. 로컬 인증서 발급

- 프로젝트 루트 폴더에서 아래 명령어 실행

```
mkcert localhost
```

- 아래 두 개 파일이 생긴다.
    - localhost-key.pem -> private key
    - localhost.pem -> public key
- 위 두개 파일은 절대 깃허브에 올리면 안된다!!!! (.gitignore 확인!!)

### 3. https 실행

- npm run dev 하면 https로 실행됨
- 자세한 내용은 vite.config.ts 체크

### 4. 브라우저에서 블록하면 인증서 브라우저에 등록

- 등록하는 방법은 브라우저마다 상이한데 보통 설정 → 보안 → 인증서 안에 있다.

### 스크린 샷
<img width="400"  alt="Screenshot 2025-11-17 at 3 11 57 PM" src="https://github.com/user-attachments/assets/36852fef-0bae-4285-adb9-ac9a1b74307b" />


## 🔗 연관된 이슈

> closes #113
