### PR TITLE
Feature: 로그인 API 연결

### DIFF
--- a/src/hooks/api/auth/useLoginMutation.ts
+++ b/src/hooks/api/auth/useLoginMutation.ts
@@ -6,10 +6,10 @@ import type {
   LoginApiErrorResponse,
   LoginResponse,
 } from "@/types/api-response-types/auth-response-types";
-import { MSW_BASE_URL } from "@/constants/url-constants";
+import { API_BASE_URL } from "@/constants/url-constants";
 
 // 로그인 요청 처리 TanStack Query 훅
-// - /users/login 엔드포인트로 로그인 요청을 보내고,
+// - /auth/login 엔드포인트로 로그인 요청을 보내고,
 // - 성공 시 서버에서 받은 user / accessToken을 Zustand 스토어에 저장
 
 export default function useLoginMutation(
@@ -22,8 +22,9 @@ export default function useLoginMutation(
     mutationKey: ["auth", "login"],
     mutationFn: async (payload) => {
       const res = await api.post<LoginResponse, AxiosResponse<LoginResponse>, LoginRequest>(
-        `${MSW_BASE_URL}/users/login`,
-        payload
+        "/auth/login",
+        payload,
+        { baseURL: API_BASE_URL }
       );
 
       return res.data;

--- a/src/mocks/handlers/auth-handler.ts
+++ b/src/mocks/handlers/auth-handler.ts
@@ -26,7 +26,7 @@ const verificationCodes = new Map<string, string>();
 
 // 인증코드 전송 API
 const postSignUpSend = http.post<never, SignUpSendRequest>(
-  `${MSW_BASE_URL}/users/signup/send/`,
+  `${MSW_BASE_URL}/auth/email_send`,
   async ({ request }) => {
     const body = await request.json();
     const { email } = body;
@@ -46,7 +46,7 @@ const postSignUpSend = http.post<never, SignUpSendRequest>(
 
 // 인증코드 확인 API
 const postSignUpVerify = http.post<never, SignUpVerifyRequest>(
-  `${MSW_BASE_URL}/users/signup/verify/`,
+  `${MSW_BASE_URL}/auth/email_verify`,
   async ({ request }) => {
     const body = await request.json();
     const { email, auth_code } = body;
@@ -108,7 +108,7 @@ const postSignUp = http.post<never, SignUpRequest>(
 
 // 로그인 API
 const postLogin = http.post<never, LoginRequest>(
-  `${MSW_BASE_URL}/users/login`,
+  `${MSW_BASE_URL}/auth/login`,
   async ({ request }) => {
     const body = (await request.json()) as LoginRequest;
     const { email, password } = body;
@@ -143,7 +143,7 @@ const postLogin = http.post<never, LoginRequest>(
 );
 
 // 토큰 갱신 API
-const postRefresh = http.post(`${MSW_BASE_URL}/user/token/refresh`, async () => {
+const postRefresh = http.post(`${MSW_BASE_URL}/auth/token/refresh`, async () => {
   return HttpResponse.json({
     tokens: {
       token_type: "Bearer",
@@ -157,12 +157,12 @@ const postRefresh = http.post(`${MSW_BASE_URL}/user/token/refresh`, async () => 
 });
 
 // 로그아웃 API
-const postLogout = http.post(`${MSW_BASE_URL}/user/logout`, async () => {
+const postLogout = http.post(`${MSW_BASE_URL}/auth/logout`, async () => {
   return HttpResponse.json({ message: "로그아웃하셨습니다" });
 });
 
 // 회원 탈퇴 API
-const deleteAccount = http.delete(`${MSW_BASE_URL}/users/signout`, async () => {
+const deleteAccount = http.delete(`${MSW_BASE_URL}/user/signout`, async () => {
   return new HttpResponse(null, { status: 204 });
 });
 


### PR DESCRIPTION
## 🚀 PR 요약

> 로그인 실제 API 연결

## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 로그인 API 연결

### 참고 사항

- 로그인 API가 401을 반환하던 원인은 신규 유저 생성 시 DB의 `is_active` 값이 기본값 false로 저장되고 있었기 때문이라고 합니다.  
백엔드 팀장님께서 수정해주신 이후, Postman에서는 정상적으로 로그인 응답을 확인했습니다.
- 다만 아직 해당 수정이 EC2 서버에 배포되기 전이라, 프론트 로컬 환경에서는 정상 동작 확인이 어려운 상태입니다!


### 스크린 샷
<img width="826" height="702" alt="스크린샷 2025-11-17 오후 7 59 48" src="https://github.com/user-attachments/assets/0180327b-8d74-461a-b82d-dc9a12feade6" />


## 🔗 연관된 이슈

> closes #160
