### PR TITLE
Feature: 비밀번호 input 보기/숨기기 아이콘 추가

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/libs/utils";
-import type { ComponentProps } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { useState, type ComponentProps } from "react";
 
 interface InputProps extends ComponentProps<"input"> {
   inputClassName?: string;
@@ -24,21 +25,38 @@ export default function Input({
   label,
   errorMessage,
   errorMessageClassName,
+  type,
   ...props
 }: InputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+  const isPassword = type === "password";
+  const inputType = isPassword ? (showPassword ? "text" : "password") : type;
+
   return (
     <div className={cn("flex flex-col gap-1 text-neutral-900", className)}>
       <label htmlFor={label} className={cn("text-base", labelClassName)}>
         {label}
       </label>
-      <input
-        id={label}
-        className={cn(
-          "w-full rounded-lg border border-neutral-400 p-2 placeholder:text-base placeholder:text-neutral-400 focus:border-green-600 focus:outline-none",
-          inputClassName
+      <div className="relative">
+        <input
+          id={label}
+          type={inputType}
+          className={cn(
+            "w-full rounded-lg border border-neutral-400 p-2 placeholder:text-base placeholder:text-neutral-400 focus:border-green-600 focus:outline-none",
+            inputClassName
+          )}
+          {...props}
+        />
+        {isPassword && (
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            className="absolute top-1/2 right-3 -translate-y-1/2 text-neutral-500 hover:text-green-600"
+          >
+            {showPassword ? <Eye size={20} /> : <EyeOff size={20} />}
+          </button>
         )}
-        {...props}
-      />
+      </div>
       <span className={cn("text-sm text-red-500", errorMessageClassName)}>{errorMessage}</span>
     </div>
   );


### PR DESCRIPTION
## 🚀 PR 요약

> 공용 Input 컴포넌트에서 `type="password"`인 경우 비밀번호 보기/숨기기 토글 기능을 추가했습니다.


## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 공용 `Input` 컴포넌트에 비밀번호 표시/숨기기 상태를 관리하는 `showPassword` state 추가
- `type="password"`일 때만 Eye / EyeOff 아이콘이 노출되도록 조건부 렌더링


### 참고 사항

- 로그인 / 회원가입 페이지에서 별도 수정 없이 `type="password"`만 지정하면 자동으로 토글 기능이 동작합니다.

### 스크린 샷

https://github.com/user-attachments/assets/72d553dd-6f3a-4b62-9a9b-a63d6cc7d274




## 🔗 연관된 이슈

> closes #162
