### PR TITLE
Feature: 로그아웃 API 연결

### DIFF
--- a/src/hooks/api/auth/useLogoutMutation.ts
+++ b/src/hooks/api/auth/useLogoutMutation.ts
@@ -4,19 +4,21 @@ import type { LogoutResponse } from "@/types/api-response-types/auth-response-ty
 import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
 import { useNavigate } from "react-router";
-import { MSW_BASE_URL } from "@/constants/url-constants";
 import { JUST_LOGGED_OUT } from "@/constants/key-constants";
+import { API_BASE_URL } from "@/constants/url-constants";
 
 export default function useLogoutMutation(
-  options?: UseMutationOptions<LogoutResponse, AxiosError>
+  options?: UseMutationOptions<LogoutResponse, AxiosError, void>
 ) {
   const navigate = useNavigate();
   const clearAuth = useAuthStore((state) => state.clearAuth);
 
-  return useMutation({
+  return useMutation<LogoutResponse, AxiosError, void>({
     mutationKey: ["auth", "logout"],
     mutationFn: () =>
-      api.post<LogoutResponse>(`${MSW_BASE_URL}/user/logout`).then((res) => res.data),
+      api
+        .post<LogoutResponse>("/auth/logout", null, { baseURL: API_BASE_URL })
+        .then((res) => res.data),
     onSettled: () => {
       clearAuth();
       sessionStorage.setItem(JUST_LOGGED_OUT, "true");


### PR DESCRIPTION
## 🚀 PR 요약

> 로그아웃 API 연결

## ✏️ 변경 유형

- feat: 새로운 기능 추가
- fix: 버그 수정

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `useLogoutMutation`에서 `/auth/logout` 최신 명세 반영

### 참고 사항

- dev 환경에서 refresh_token이 `Secure` 쿠키로 내려오고 있어, HTTP 환경에서는 저장/전송되지 않습니다. 그로 인해 로그아웃 시 `Refresh token missing` 에러가 발생하는 것 같습니다...🤔

<img width="536" height="494" alt="스크린샷 2025-11-18 오전 11 50 09" src="https://github.com/user-attachments/assets/ac17bfda-7a97-4a9b-ab9b-495caa9cca94" />

- 환경 세팅이 완료되면 정상 동작 여부 확인 후 Ready for Review로 변경하겠습니다!

<br>

### 정상 작동 확인 


<img width="756" height="647" alt="스크린샷 2025-11-19 오전 9 48 57" src="https://github.com/user-attachments/assets/731c333a-69d7-47d2-b1cf-92622889c1e5" />

<br>

<img width="756" height="236" alt="스크린샷 2025-11-19 오전 9 49 17" src="https://github.com/user-attachments/assets/901c8f7f-80fd-453b-ba71-28bfc90afe23" />


## 🔗 연관된 이슈

> closes #165
