### PR TITLE
Feature: 회원탈퇴 API 연결 

### DIFF
--- a/src/hooks/api/auth/useDeleteAccount.ts
+++ b/src/hooks/api/auth/useDeleteAccount.ts
@@ -1,4 +1,4 @@
-import { MSW_BASE_URL } from "@/constants/url-constants";
+import { API_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { ApiError } from "@/types/api-response-types/auth-response-types";
 import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
@@ -10,7 +10,7 @@ export default function useDeleteAccount(
   return useMutation<void, AxiosError<ApiError>, void>({
     mutationKey: ["auth", "deleteAccount"],
     mutationFn: async () => {
-      await api.delete(`${MSW_BASE_URL}/users/signout`);
+      await api.delete("/user/signout", { baseURL: API_BASE_URL });
     },
     ...options,
   });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -13,9 +13,8 @@ import type { AxiosError } from "axios";
 import { useForm } from "react-hook-form";
 import { Link, useNavigate } from "react-router";
 
-const getApiError = (error: unknown) => {
-  const axiosError = error as AxiosError<LoginApiErrorResponse>;
-  return axiosError?.response?.data?.error ?? null;
+const getApiError = (error: AxiosError<LoginApiErrorResponse>) => {
+  return error.response?.data?.error ?? null;
 };
 
 export default function Login() {
@@ -43,11 +42,18 @@ export default function Login() {
       sessionStorage.setItem(JUST_LOGGED_IN, "true");
       navigate("/", { replace: true });
     },
-    onError: (error) => {
-      const axiosError = error as AxiosError<LoginApiErrorResponse>;
-      const status = axiosError?.response?.status ?? axiosError?.response?.data?.code;
+    onError: (error: AxiosError<LoginApiErrorResponse>) => {
+      const status = error?.response?.status;
+      const code = error?.response?.data?.code;
       const msg = getApiError(error) ?? "로그인 중 오류가 발생했습니다.";
 
+      // 이미 탈퇴한 계정 처리
+      if (code === "user_inactive") {
+        setError("email", { message: "이미 탈퇴한 계정입니다." });
+        return;
+      }
+
+      // 기본 에러 처리
       if (status === 400 || status === 401) {
         setError("email", { message: "이메일 또는 비밀번호를 확인해주세요." });
       } else if (status === 500) {

--- a/src/types/api-response-types/auth-response-types.ts
+++ b/src/types/api-response-types/auth-response-types.ts
@@ -17,7 +17,7 @@ export interface Token {
 }
 export interface ApiError {
   error: string;
-  code: number;
+  code: string | number;
 }
 
 // 회원가입 응답


### PR DESCRIPTION
## 🚀 PR 요약

> 회원탈퇴 API 연결 및 탈퇴한계정 로그인 시 에러 메세지 처리 추가

## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### 작업 사항

- `useDeleteAccount` 훅에 `/user/signout` DELETE API 연동
- 탈퇴한 계정으로 로그인 시(`user_inactive`) 에러 메시지 추가

### 참고 사항

- Postman으로 실제 `/user/signout` DELETE 요청 테스트 후 200 응답 확인
- dev 환경에서는 이미 탈퇴한 계정에 대해 `user_inactive` 응답 확인


### 스크린 샷

<img width="1132" height="864" alt="스크린샷 2025-11-18 오후 1 36 11" src="https://github.com/user-attachments/assets/ce168f6c-95c1-4d2d-a671-5976e415c3a4" />

<img width="706" height="601" alt="스크린샷 2025-11-18 오후 1 58 57" src="https://github.com/user-attachments/assets/547356cf-e8c2-4781-b2ad-b39c5037862f" />


## 🔗 연관된 이슈

> closes #167 <- 이번에 작업한 이슈 번호
