### PR TITLE
Feature: 토큰 갱신 api 연결

### DIFF
--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -11,6 +11,7 @@ api.interceptors.request.use((config) => {
   console.log("요청 인터셉터 실행");
 
   const token = useAuthStore.getState().accessToken;
+  // const token = "aaa"; // ← 테스트용
 
   // headers가 undefined일 수 있으므로 안전하게 기본값 설정
   config.headers = config.headers ?? {};
@@ -30,15 +31,17 @@ api.interceptors.response.use(
   // 실패 응답
   async (error: AxiosError) => {
     const { response, config } = error;
+    console.log("응답 인터셉터 진입", response?.status, config?.url);
 
     // accessToken 만료 감시 및 중복 재시도 방지
     if (response?.status === 401 && config && !(config as any)._retry) {
+      console.log("401 감지, refresh 시도");
       (config as any)._retry = true;
 
       try {
         // refresh 요청 (rToken은 쿠키로 자동 전송)
         const { data } = await axios.post(
-          "/user/token/refresh",
+          "/auth/token/refresh",
           {},
           {
             baseURL: API_BASE_URL,

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -51,7 +51,7 @@ api.interceptors.response.use(
         console.log("새 accessToken 발급 성공");
 
         // 새 accessToken 전역 상태에 저장
-        const newAccessToken = data?.tokens?.access_token ?? data?.access_token;
+        const newAccessToken = data?.tokens?.access_token ?? data?.access;
         if (newAccessToken) {
           const state = useAuthStore.getState();
           useAuthStore.setState({ ...state, accessToken: newAccessToken });


### PR DESCRIPTION
## 🚀 PR 요약

> 토큰 갱신 api 연결

## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### Postman 기반 서버 응답 테스트

- POST /auth/login → 응답에서 access / refresh 확인

<img width="731" height="786" alt="스크린샷 2025-11-19 오전 11 04 38" src="https://github.com/user-attachments/assets/0f8e086b-a665-4d2d-a0d1-2d71799ac89c" />


<img width="739" height="432" alt="스크린샷 2025-11-19 오전 10 59 24" src="https://github.com/user-attachments/assets/0fc9d904-c116-461c-849d-e84f92f0ce5d" />


<br>
<br>

- POST /auth/token/refresh → Body(JSON)에 refresh 토큰 전달

<img width="739" height="639" alt="스크린샷 2025-11-19 오전 11 00 07" src="https://github.com/user-attachments/assets/6889b91d-87a5-46c5-975a-39e4dadbc327" />

```json
{ "access": "<NEW_ACCESS_JWT>", "refresh": "<REFRESH_JWT>" }
```
 → 응답에서 위 형태로 새로운 accessToken이 정상 발급되는지 확인


<br>

### 인터셉터 로직
- 요청 인터셉터
   - Zustand에 저장된 accessToken을 자동으로 읽어 Authorization 헤더에 포함

- 응답 인터셉터
   - 서버에서 401(UnAuthorized) 응답이 오면
   → 한 번만 _retry = true 표시 후 /auth/token/refresh 자동 호출
    - refresh 성공 시: 
       - 새 accessToken을 Zustand store에 업데이트
       - 실패한 기존 요청을 api(config)로 다시 재시도
 
    - refresh 실패 시: clearAuth() 호출하여 인증 상태 초기화

## 🔗 연관된 이슈

> closes #171
