### PR TITLE
Feature: 마이페이지 API 연결 (북마크/이미지 검색 히스토리)

### DIFF
--- a/src/hooks/api/my-page/index.ts
+++ b/src/hooks/api/my-page/index.ts
@@ -2,5 +2,12 @@ import useNicknameEdit from "@/hooks/api/my-page/useNicknameEdit";
 import usePasswordEdit from "@/hooks/api/my-page/usePasswordEdit";
 import useBookmarkList from "@/hooks/api/my-page/useBookmarkList";
 import useImageSearchList from "@/hooks/api/my-page/useImageSearchList";
+import useImageSearchPillDetail from "@/hooks/api/my-page/useImageSearchPillDetail";
 
-export { useNicknameEdit, usePasswordEdit, useBookmarkList, useImageSearchList };
+export {
+  useNicknameEdit,
+  usePasswordEdit,
+  useBookmarkList,
+  useImageSearchList,
+  useImageSearchPillDetail,
+};

--- a/src/hooks/api/my-page/useBookmarkList.ts
+++ b/src/hooks/api/my-page/useBookmarkList.ts
@@ -1,13 +1,13 @@
-import { MSW_BASE_URL } from "@/constants/url-constants";
+import { API_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { BookmarkListResponse } from "@/types/api-response-types/bookmark-response-types";
 import { useQuery } from "@tanstack/react-query";
 
 export default function useBookmarkList() {
   return useQuery<BookmarkListResponse>({
-    queryKey: ["bookmark"],
+    queryKey: ["my-page", "bookmark"],
     queryFn: async () => {
-      const res = await api.get(`${MSW_BASE_URL}/bookmark`);
+      const res = await api.get("/bookmarks", { baseURL: API_BASE_URL });
       return res.data;
     },
   });

--- a/src/hooks/api/my-page/useBookmarkList.ts
+++ b/src/hooks/api/my-page/useBookmarkList.ts
@@ -3,11 +3,11 @@ import { api } from "@/libs/axios";
 import type { BookmarkListResponse } from "@/types/api-response-types/bookmark-response-types";
 import { useQuery } from "@tanstack/react-query";
 
-export default function useBookmarkList() {
+export default function useBookmarkList(page = 1) {
   return useQuery<BookmarkListResponse>({
-    queryKey: ["my-page", "bookmark"],
+    queryKey: ["my-page", "bookmark", page],
     queryFn: async () => {
-      const res = await api.get("/bookmarks", { baseURL: API_BASE_URL });
+      const res = await api.get("/bookmarks", { baseURL: API_BASE_URL, params: { page } });
       return res.data;
     },
   });

--- a/src/hooks/api/my-page/useImageSearchList.ts
+++ b/src/hooks/api/my-page/useImageSearchList.ts
@@ -2,7 +2,7 @@ import {
   IMAGE_SEARCH_MAX_COUNT,
   IMAGE_SEARCH_REFETCH_INTERVAL_MS,
 } from "@/constants/api-constants";
-import { MSW_BASE_URL } from "@/constants/url-constants";
+import { API_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { ImageSearchApiResponse } from "@/types/api-response-types/image-search-types";
 import { useQuery } from "@tanstack/react-query";
@@ -11,7 +11,7 @@ export default function useImageSearchList() {
   return useQuery<ImageSearchApiResponse>({
     queryKey: ["mypage", "image-search-list"],
     queryFn: async () => {
-      const res = await api.get(`${MSW_BASE_URL}/my_requests`);
+      const res = await api.get("/pills/search-histories/", { baseURL: API_BASE_URL });
       const data = res.data;
 
       // 리스트 10개만 노출 (명세 참고)

--- a/src/hooks/api/my-page/useImageSearchPillDetail.ts
+++ b/src/hooks/api/my-page/useImageSearchPillDetail.ts
@@ -1,12 +1,12 @@
-import { MSW_BASE_URL } from "@/constants/url-constants";
+import { API_BASE_URL } from "@/constants/url-constants";
 import { api } from "@/libs/axios";
 import type { PillDetail } from "@/types/api-response-types/pill-response-types";
 import { useQuery } from "@tanstack/react-query";
 
-// /my_requests 응답의 item_seq를 이용해 의약품 상세 정보 요청
+// /pills/search-histories/ 응답의 item_seq를 이용해 의약품 상세 정보 요청
 // - 검색 결과 completed 상태일 때만 호출
 async function fetchPillDetail(itemSeq: string) {
-  const { data } = await api.get<PillDetail>(`${MSW_BASE_URL}/pills/${itemSeq}`);
+  const { data } = await api.get<PillDetail>(`/pills/${itemSeq}`, { baseURL: API_BASE_URL });
   return data;
 }
 

--- a/src/hooks/api/useToggleBookmark.ts
+++ b/src/hooks/api/useToggleBookmark.ts
@@ -20,12 +20,7 @@ export default function useToggleBookmark(
       const { id, isDelete } = toggleParams;
 
       if (isDelete) {
-        const res = await api.delete(`${API_BASE_URL}/bookmarks/`, {
-          data: {
-            item_seq: id,
-          },
-        });
-
+        const res = await api.delete(`${API_BASE_URL}/bookmarks/${encodeURIComponent(id)}`);
         return res.data;
       } else {
         const res = await api.post(`${API_BASE_URL}/bookmarks/`, {

--- a/src/mocks/handlers/my-page-handlers.ts
+++ b/src/mocks/handlers/my-page-handlers.ts
@@ -28,7 +28,7 @@ const patchPassword = http.patch(`${MSW_BASE_URL}/mypage/password`, async ({ req
 });
 
 // 북마크 조회
-const getBookmarks = http.get(`${MSW_BASE_URL}/bookmark`, () => {
+const getBookmarks = http.get(`${MSW_BASE_URL}/bookmarks`, () => {
   const bookmarked = mockPills.filter((pill) => pill.is_marked);
 
   const response = {

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -97,7 +97,10 @@ export default function Mypage() {
                         <p className="text-center text-neutral-500">북마크된 약이 없습니다.</p>
                       ) : (
                         bookmarkedPills.map((pill) => (
-                          <PillListItem key={pill.item_seq} pill={{ ...pill, is_marked: true }} />
+                          <PillListItem
+                            key={pill.item_seq}
+                            pill={{ ...pill, is_marked: true, efcy_qesitm: "" }}
+                          />
                         ))
                       )}
                     </div>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -17,7 +17,7 @@ import { Link, useNavigate } from "react-router";
 export default function Mypage() {
   // 북마크 목록
   const { data, isPending: isBookmarkListPending } = useBookmarkList();
-  const bookmarkedPills = data?.pills ?? [];
+  const bookmarkedPills = data ?? [];
 
   // 이미지 검색 목록
   const { data: imageData } = useImageSearchList();

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -97,7 +97,7 @@ export default function Mypage() {
                         <p className="text-center text-neutral-500">북마크된 약이 없습니다.</p>
                       ) : (
                         bookmarkedPills.map((pill) => (
-                          <PillListItem key={pill.item_seq} pill={pill} />
+                          <PillListItem key={pill.item_seq} pill={{ ...pill, is_marked: true }} />
                         ))
                       )}
                     </div>

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -116,7 +116,10 @@ export default function Mypage() {
                         <p className="text-center text-neutral-500">이미지 검색 내역이 없습니다.</p>
                       )}
                       {imageSearchList.map((record: ImageSearchApiRecord) => (
-                        <ImageSearchPillListItem key={record.created_at} record={record} />
+                        <ImageSearchPillListItem
+                          key={`${record.filename}-${record.status}`}
+                          record={record}
+                        />
                       ))}
                     </div>
                   ),

--- a/src/types/api-response-types/bookmark-response-types.ts
+++ b/src/types/api-response-types/bookmark-response-types.ts
@@ -1,5 +1,3 @@
-import type { Pill } from "@/types/api-response-types/pill-response-types";
-
 export interface BoomarkResponse {
   success: boolean;
   message: string;
@@ -7,8 +5,12 @@ export interface BoomarkResponse {
 }
 
 // 마이페이지 북마크 리스트
-export interface BookmarkListResponse {
-  limit: number;
-  total: number;
-  pills: Pill[];
+export interface BookmarkItem {
+  id: number;
+  item_seq: string;
+  item_name: string;
+  entp_name: string;
+  item_image_url: string;
 }
+
+export type BookmarkListResponse = BookmarkItem[];

--- a/src/types/api-response-types/bookmark-response-types.ts
+++ b/src/types/api-response-types/bookmark-response-types.ts
@@ -1,3 +1,5 @@
+import type { Pill } from "@/types/api-response-types/pill-response-types";
+
 export interface BoomarkResponse {
   success: boolean;
   message: string;
@@ -5,12 +7,6 @@ export interface BoomarkResponse {
 }
 
 // 마이페이지 북마크 리스트
-export interface BookmarkItem {
-  id: number;
-  item_seq: string;
-  item_name: string;
-  entp_name: string;
-  item_image_url: string;
-}
+export type BookmarkItem = Omit<Pill, "is_marked" | "efcy_qesitm">;
 
 export type BookmarkListResponse = BookmarkItem[];

--- a/src/types/api-response-types/image-search-types.ts
+++ b/src/types/api-response-types/image-search-types.ts
@@ -8,7 +8,6 @@ export type ImageSearchStatus = "pending" | "completed" | "completed_failed";
 export interface ImageSearchApiRecordBase {
   filename: string;
   url: string;
-  created_at: string;
 }
 
 export type ImageSearchApiRecord =

--- a/src/types/api-response-types/pill-response-types.ts
+++ b/src/types/api-response-types/pill-response-types.ts
@@ -8,10 +8,10 @@ export interface PillList {
 export interface Pill {
   item_seq: string;
   item_name: string;
-  efcy_qesitm: string;
+  efcy_qesitm?: string;
   entp_name: string;
   item_image_url: string;
-  is_marked: boolean;
+  is_marked?: boolean;
 }
 
 export interface PillDetail extends Pill {

--- a/src/types/api-response-types/pill-response-types.ts
+++ b/src/types/api-response-types/pill-response-types.ts
@@ -8,10 +8,10 @@ export interface PillList {
 export interface Pill {
   item_seq: string;
   item_name: string;
-  efcy_qesitm?: string;
+  efcy_qesitm: string;
   entp_name: string;
   item_image_url: string;
-  is_marked?: boolean;
+  is_marked: boolean;
 }
 
 export interface PillDetail extends Pill {


### PR DESCRIPTION
## 🚀 PR 요약

> 마이페이지 API 연동 (북마크/이미지 검색 히스토리)

## ✏️ 변경 유형

- feat: 새로운 기능 추가

## 🗒️ 상세 내용 (선택)

### 작업 사항

- 마이페이지 API 연결 (북마크/이미지 검색 히스토리)

### 참고 사항
마이페이지 이미지 조회 리스트 렌더링 시 유니크 key 용도로 사용하려던 
`created_at` 필드는 현재 API 응답에서 제외되어 있는 것을 확인했습니다.

서버에서 최신순 정렬을 보장해주고 계시긴 하지만, 
`map` 렌더링 시 index를 key로 사용하는 것은 위험할 수 있어 

`key={`${record.filename}-${record.status}`}` 형태로 적용했습니다!


## 🔗 연관된 이슈

> closes #172
